### PR TITLE
Breaking changes to decouple semaphores and clients

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.4.0
+      hooks:
+        - id: check-yaml
+          args: [--unsafe]
+          exclude: '.*templates.*.yaml'
+        - id: end-of-file-fixer
+          exclude: 'CHANGELOG.md'
+        - id: trailing-whitespace
+          exclude: 'CHANGELOG.md'
+        - id: check-ast
+    - repo: https://github.com/gruntwork-io/pre-commit
+      rev: v0.1.12
+      hooks:
+        - id: shellcheck
+    - repo: https://github.com/psf/black
+      rev: 20.8b1
+      hooks:
+        - id: black

--- a/aio_aws/__init__.py
+++ b/aio_aws/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .version import __version__  as version
+from .version import __version__ as version
 
 VERSION = version

--- a/aio_aws/aio_aws_batch.py
+++ b/aio_aws/aio_aws_batch.py
@@ -736,9 +736,7 @@ def parse_job_description(job_id: str, jobs: Dict) -> Optional[Dict]:
     return job_desc
 
 
-async def aio_batch_job_submit(
-    job: AWSBatchJob, config: AWSBatchConfig = None
-) -> Dict:
+async def aio_batch_job_submit(job: AWSBatchJob, config: AWSBatchConfig = None) -> Dict:
     """
     Asynchronous coroutine to submit a batch job; for a successful
     job submission, the jobId and other submission details are

--- a/aio_aws/aio_aws_config.py
+++ b/aio_aws/aio_aws_config.py
@@ -131,9 +131,7 @@ def aio_aws_session(
 
 
 async def aio_aws_client(
-    service_name: str,
-    aio_aws_config: aiobotocore.config.AioConfig = None,
-    **kwargs
+    service_name: str, aio_aws_config: aiobotocore.config.AioConfig = None, **kwargs
 ):
     """
     Yield an asyncio AWS client with an option to provide a client-specific config; this is a
@@ -201,7 +199,7 @@ class AioAWSConfig:
         return cls()
 
     def __post_init__(self):
-        
+
         # see also aiobotocore.endpoint.AioEndpointCreator.create_endpoint
         # for all the options that config details can provide for aiohttp session
 

--- a/aio_aws/aio_aws_lambda.py
+++ b/aio_aws/aio_aws_lambda.py
@@ -243,14 +243,12 @@ async def run_lambda_functions(lambda_functions: List[AWSLambdaFunction]):
         aws_region=os.getenv("AWS_DEFAULT_REGION", "us-west-2"),
         min_jitter=0.2,
         max_jitter=0.8,
-        max_pool_connections=MAX_POOL_CONNECTIONS
+        max_pool_connections=MAX_POOL_CONNECTIONS,
     )
     lambda_tasks = []
     async with config.create_client("lambda") as lambda_client:
         for lambda_func in lambda_functions:
-            lambda_task = asyncio.create_task(
-                lambda_func.invoke(config, lambda_client)
-            )
+            lambda_task = asyncio.create_task(lambda_func.invoke(config, lambda_client))
             lambda_tasks.append(lambda_task)
         await asyncio.gather(*lambda_tasks)
 

--- a/aio_aws/async_executor.py
+++ b/aio_aws/async_executor.py
@@ -103,13 +103,13 @@ def loop_mgr(loop: asyncio.AbstractEventLoop):
         # the loop was stopped and concurrent.futures.Executor
         # promises to complete tasks on shutdown.
         while True:
-            tasks = asyncio.Task.all_tasks(loop=loop)
+            tasks = asyncio.all_tasks(loop=loop)
             pending = [t for t in tasks if not t.done()]
             loop.run_until_complete(asyncio.gather(*pending))
 
             # ensure the task collection is updated
             # (this is _not_ redundant)
-            tasks = asyncio.Task.all_tasks(loop=loop)
+            tasks = asyncio.all_tasks(loop=loop)
             if all([t.done() for t in tasks]):
                 break
 

--- a/aio_aws/async_main.py
+++ b/aio_aws/async_main.py
@@ -22,7 +22,12 @@ from typing import Awaitable
 
 def main(run: Awaitable):
     """Run main loop"""
-    loop = asyncio.get_event_loop()
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
     try:
         loop.run_until_complete(run)
     finally:

--- a/tests/aws_aio_fixtures.py
+++ b/tests/aws_aio_fixtures.py
@@ -15,7 +15,6 @@ from itertools import chain
 import aiobotocore
 import aiobotocore.config
 import aiohttp
-
 # Third Party
 import pytest
 from aiobotocore.config import AioConfig

--- a/tests/aws_aio_fixtures.py
+++ b/tests/aws_aio_fixtures.py
@@ -15,6 +15,7 @@ from itertools import chain
 import aiobotocore
 import aiobotocore.config
 import aiohttp
+
 # Third Party
 import pytest
 from aiobotocore.config import AioConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ import pytest
 
 from aio_aws.aio_aws_batch import AWSBatchDB
 
-
 pytest_plugins = [
     "tests.aws_fixtures",
     "tests.aiomoto_fixtures",

--- a/tests/test_aio_aws_batch.py
+++ b/tests/test_aio_aws_batch.py
@@ -33,7 +33,6 @@ import botocore.exceptions
 import pytest
 
 from aio_aws import aio_aws_batch
-from aio_aws.aio_aws_config import response_success
 from aio_aws.aio_aws_batch import aio_batch_get_logs
 from aio_aws.aio_aws_batch import aio_batch_job_logs
 from aio_aws.aio_aws_batch import aio_batch_job_manager
@@ -44,6 +43,7 @@ from aio_aws.aio_aws_batch import aio_batch_job_waiter
 from aio_aws.aio_aws_batch import aio_batch_run_jobs
 from aio_aws.aio_aws_batch import AWSBatchConfig
 from aio_aws.aio_aws_batch import AWSBatchJob
+from aio_aws.aio_aws_config import response_success
 from tests.aiomoto_fixtures import aio_batch_infrastructure
 from tests.aiomoto_fixtures import AioAwsBatchClients
 from tests.aiomoto_fixtures import AioAwsBatchInfrastructure

--- a/tests/test_aio_aws_config.py
+++ b/tests/test_aio_aws_config.py
@@ -57,4 +57,6 @@ async def test_async_delay_defaults():
 async def test_async_jitter_defaults():
     pause = await aio_aws.aio_aws_config.jitter("jitter_task")
     assert isinstance(pause, float)
-    assert aio_aws.aio_aws_config.MIN_JITTER <= pause <= aio_aws.aio_aws_config.MAX_JITTER
+    assert (
+        aio_aws.aio_aws_config.MIN_JITTER <= pause <= aio_aws.aio_aws_config.MAX_JITTER
+    )

--- a/tests/test_aio_aws_lambda.py
+++ b/tests/test_aio_aws_lambda.py
@@ -147,13 +147,16 @@ async def test_async_lambda_invoke(
 
     func: AWSLambdaFunction = aws_lambda_func
 
-    response = await func.invoke(lambda_config)
-    assert response_success(response)
-    # A successful response could have handled errors
-    if func.content is None:
-        assert func.error
-    else:
-        assert func.content
+    async with lambda_config.create_client("lambda") as lambda_client:
 
-    # since this function should work, test the response data
-    assert func.content == {"statusCode": 200, "body": {"i": 1}}
+        response = await func.invoke(lambda_config, lambda_client)
+        assert response_success(response)
+        # A successful response could have handled errors
+        if func.content is None:
+            assert func.error
+        else:
+            assert func.content
+
+        # since this function should work, test the response data
+        assert func.content == {"statusCode": 200, "body": {"i": 1}}
+

--- a/tests/test_aio_aws_lambda.py
+++ b/tests/test_aio_aws_lambda.py
@@ -159,4 +159,3 @@ async def test_async_lambda_invoke(
 
         # since this function should work, test the response data
         assert func.content == {"statusCode": 200, "body": {"i": 1}}
-


### PR DESCRIPTION
- try to decouple some semaphores from client creation and configs
- try to avoid instantiating any asyncio objects until they are used
  - various bugs arise from creating asyncio objects in one loop vs. another
 