### PR TITLE
Revise lambda.invoke to return lambda

### DIFF
--- a/aio_aws/aio_aws_lambda.py
+++ b/aio_aws/aio_aws_lambda.py
@@ -144,7 +144,7 @@ class AWSLambdaFunction:
 
     async def invoke(
         self, config: AioAWSConfig, lambda_client: aiobotocore.client.AioBaseClient
-    ) -> Dict:
+    ) -> "AWSLambdaFunction":
         """
         Asynchronous coroutine to invoke a lambda function; this
         updates the ``response`` and calls the py:meth:`.read_response`
@@ -177,7 +177,8 @@ class AWSLambdaFunction:
                     else:
                         # TODO: are there some failures that could be recovered here?
                         LOGGER.error("AWS Lambda (%s) invoke failure.", self.name)
-                    return response
+
+                    return self
 
                 except botocore.exceptions.ClientError as err:
                     error = err.response.get("Error", {})

--- a/tests/test_aio_aws_lambda.py
+++ b/tests/test_aio_aws_lambda.py
@@ -149,13 +149,14 @@ async def test_async_lambda_invoke(
 
     async with lambda_config.create_client("lambda") as lambda_client:
 
-        response = await func.invoke(lambda_config, lambda_client)
-        assert response_success(response)
+        lambda_func = await func.invoke(lambda_config, lambda_client)
+        assert id(lambda_func) == id(func)
+        assert response_success(lambda_func.response)
         # A successful response could have handled errors
-        if func.content is None:
-            assert func.error
+        if lambda_func.content is None:
+            assert lambda_func.error
         else:
-            assert func.content
+            assert lambda_func.content
 
         # since this function should work, test the response data
-        assert func.content == {"statusCode": 200, "body": {"i": 1}}
+        assert lambda_func.content == {"statusCode": 200, "body": {"i": 1}}


### PR DESCRIPTION
This makes it easier to use an AWS lambda.invoke with `asyncio.as_completed` to get back the lambda object.