### PR TITLE
Fix lambda logging

### DIFF
--- a/aio_aws/aio_aws_batch.py
+++ b/aio_aws/aio_aws_batch.py
@@ -247,7 +247,9 @@ from aio_aws.aio_aws_config import AioAWSConfig
 from aio_aws.aio_aws_config import delay
 from aio_aws.aio_aws_config import jitter
 from aio_aws.aio_aws_config import response_success
-from aio_aws.logger import LOGGER
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 #: batch job startup pause (seconds)
 BATCH_STARTUP_PAUSE: float = 30

--- a/aio_aws/aio_aws_batch.py
+++ b/aio_aws/aio_aws_batch.py
@@ -757,7 +757,7 @@ async def aio_batch_job_submit(job: AWSBatchJob, config: AWSBatchConfig = None) 
 
     async with config.create_batch_client() as batch_client:
         tries = 0
-        while tries < config.retries:
+        while tries <= config.retries:
             tries += 1
             try:
                 params = job.params
@@ -790,7 +790,7 @@ async def aio_batch_job_submit(job: AWSBatchJob, config: AWSBatchConfig = None) 
             except botocore.exceptions.ClientError as err:
                 error = err.response.get("Error", {})
                 if error.get("Code") == "TooManyRequestsException":
-                    if tries < config.retries:
+                    if tries <= config.retries:
                         # add an extra random sleep period to avoid API throttle
                         await jitter(
                             "batch-job-submit", config.min_jitter, config.max_jitter
@@ -818,14 +818,14 @@ async def aio_batch_job_status(
 
     async with config.create_batch_client() as batch_client:
         tries = 0
-        while tries < config.retries:
+        while tries <= config.retries:
             tries += 1
             try:
                 return await batch_client.describe_jobs(jobs=jobs)
             except botocore.exceptions.ClientError as err:
                 error = err.response.get("Error", {})
                 if error.get("Code") == "TooManyRequestsException":
-                    if tries < config.retries:
+                    if tries <= config.retries:
                         # add an extra random sleep period to avoid API throttle
                         await jitter(
                             "batch-job-status", config.min_jitter, config.max_jitter
@@ -870,7 +870,7 @@ async def aio_batch_job_logs(
 
     async with config.create_logs_client() as logs_client:
         tries = 0
-        while tries < config.retries:
+        while tries <= config.retries:
             tries += 1
             try:
                 log_events = []
@@ -921,7 +921,7 @@ async def aio_batch_job_logs(
             except botocore.exceptions.ClientError as err:
                 error = err.response.get("Error", {})
                 if error.get("Code") == "TooManyRequestsException":
-                    if tries < config.retries:
+                    if tries <= config.retries:
                         # add an extra random sleep period to avoid API throttle
                         await jitter(
                             "batch-job-logs", config.min_jitter, config.max_jitter
@@ -951,7 +951,7 @@ async def aio_batch_job_terminate(
     async with config.create_batch_client() as batch_client:
 
         tries = 0
-        while tries < config.retries:
+        while tries <= config.retries:
             tries += 1
             try:
                 LOGGER.info("AWS Batch job to terminate: %s, %s", job_id, reason)
@@ -962,7 +962,7 @@ async def aio_batch_job_terminate(
             except botocore.exceptions.ClientError as err:
                 error = err.response.get("Error", {})
                 if error.get("Code") == "TooManyRequestsException":
-                    if tries < config.retries:
+                    if tries <= config.retries:
                         # add an extra random sleep period to avoid API throttle
                         await jitter(
                             "batch-job-terminate", config.min_jitter, config.max_jitter

--- a/aio_aws/aio_aws_config.py
+++ b/aio_aws/aio_aws_config.py
@@ -49,7 +49,9 @@ import aiobotocore.session
 import botocore.client
 import botocore.endpoint
 
-from aio_aws.logger import LOGGER
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 #: max_pool_connections for AWS clients (10 by default)
 MAX_POOL_CONNECTIONS = botocore.endpoint.MAX_POOL_CONNECTIONS

--- a/aio_aws/aio_aws_config.py
+++ b/aio_aws/aio_aws_config.py
@@ -194,7 +194,7 @@ class AioAWSConfig:
     #: an optional AWS region name
     aws_region: str = None
     #: a number of retries for an AWS client request/response
-    retries: int = 5
+    retries: int = 4
     #: an asyncio.sleep for ``random.uniform(min_pause, max_pause)``
     min_pause: float = MIN_PAUSE
     #: an asyncio.sleep for ``random.uniform(min_pause, max_pause)``

--- a/aio_aws/aio_aws_lambda.py
+++ b/aio_aws/aio_aws_lambda.py
@@ -71,7 +71,9 @@ from aio_aws.aio_aws_config import AioAWSConfig
 from aio_aws.aio_aws_config import jitter
 from aio_aws.aio_aws_config import MAX_POOL_CONNECTIONS
 from aio_aws.aio_aws_config import response_success
-from aio_aws.logger import LOGGER
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 @dataclass

--- a/aio_aws/aio_aws_lambda.py
+++ b/aio_aws/aio_aws_lambda.py
@@ -56,10 +56,13 @@ minimal billing period, so it's as cheap as it can be and could fit within a mon
 
 import asyncio
 import base64
+import concurrent.futures
 import json
 import os
 import time
 from dataclasses import dataclass
+from functools import partial
+from json import JSONDecodeError
 from typing import Any
 from typing import Dict
 from typing import List
@@ -74,6 +77,8 @@ from aio_aws.aio_aws_config import response_success
 from aio_aws.logger import get_logger
 
 LOGGER = get_logger(__name__)
+
+MAXIMUM_PAYLOAD_SIZE = 6291556
 
 
 @dataclass
@@ -107,6 +112,7 @@ class AWSLambdaFunction:
     payload: bytes = b""  # or a file
     qualifier: str = None
     response: Dict = None
+    data: Any = None
     content: Any = None
     error: Any = None
     logs: Any = None
@@ -159,7 +165,7 @@ class AWSLambdaFunction:
         """
         async with config.semaphore:
             tries = 0
-            while tries < config.retries:
+            while tries <= config.retries:
                 tries += 1
                 try:
                     LOGGER.debug("AWS Lambda params: %s", self.params)
@@ -171,27 +177,30 @@ class AWSLambdaFunction:
                     if response_success(response):
                         await self.read_response()  # updates self.content
                         if self.content:
-                            LOGGER.info("AWS Lambda (%s) invoked OK", self.name)
+                            LOGGER.info("AWS Lambda invoked OK: %s", self.name)
                         elif self.error:
                             LOGGER.error(
-                                "AWS Lambda (%s) error: ", self.name, self.error
+                                "AWS Lambda error: %s, %s", self.name, self.error
                             )
                     else:
                         # TODO: are there some failures that could be recovered here?
-                        LOGGER.error("AWS Lambda (%s) invoke failure.", self.name)
+                        LOGGER.error("AWS Lambda invoke failure: %s", self.name)
 
                     return self
 
                 except botocore.exceptions.ClientError as err:
-                    error = err.response.get("Error", {})
+                    response = err.response
+                    LOGGER.error("AWS Lambda client error: %s, %s", self.name, response)
+                    error = response.get("Error", {})
                     if error.get("Code") == "TooManyRequestsException":
-                        if tries < config.retries:
-                            # add an extra random sleep period to avoid API throttle
+                        if tries <= config.retries:
                             await jitter(
-                                "lambda-invoke", config.min_jitter, config.max_jitter
+                                "lambda-retry", config.min_jitter, config.max_jitter
                             )
                         continue  # allow it to retry, if possible
                     else:
+                        self.response = response
+                        self.error = error
                         raise
             else:
                 raise RuntimeError("AWS Lambda invoke exceeded retries")
@@ -214,14 +223,22 @@ class AWSLambdaFunction:
             if response_payload:
 
                 async with response_payload as stream:
-                    data = await stream.read()
+                    self.data = await stream.read()
 
-                body = data.decode()
+                body = self.data.decode()
 
                 if self.response.get("FunctionError"):
                     self.error = body
+                    try:
+                        self.error = json.loads(body)
+                    except JSONDecodeError:
+                        pass
                 else:
-                    self.content = json.loads(body)
+                    self.content = body
+                    try:
+                        self.content = json.loads(body)
+                    except JSONDecodeError:
+                        pass
 
 
 async def run_lambda_functions(lambda_functions: List[AWSLambdaFunction]):
@@ -243,6 +260,7 @@ async def run_lambda_functions(lambda_functions: List[AWSLambdaFunction]):
         results of any lambda response in func.response
     """
     config = AioAWSConfig(
+        retries=0,
         aws_region=os.getenv("AWS_DEFAULT_REGION", "us-west-2"),
         min_jitter=0.2,
         max_jitter=0.8,
@@ -256,6 +274,40 @@ async def run_lambda_functions(lambda_functions: List[AWSLambdaFunction]):
         await asyncio.gather(*lambda_tasks)
 
 
+async def run_lambda_function_thread_pool(
+    lambda_functions: List[AWSLambdaFunction], n_tasks: int = 4
+):
+    config = AioAWSConfig(
+        retries=0,
+        aws_region=os.getenv("AWS_DEFAULT_REGION", "us-west-2"),
+        min_jitter=0.2,
+        max_jitter=0.8,
+        max_pool_connections=MAX_POOL_CONNECTIONS,
+    )
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        loop = asyncio.get_running_loop()
+        lambda_tasks = []
+
+        async with config.create_client("lambda") as lambda_client:
+            for lambda_func in lambda_functions:
+                func = partial(
+                    lambda_func.invoke,
+                    config=config,
+                    lambda_client=lambda_client,
+                )
+                lambda_task = await loop.run_in_executor(executor=executor, func=func)
+                lambda_tasks.append(lambda_task)
+
+                # Limit concurrency to some extent
+                if len(lambda_tasks) == n_tasks:
+                    await asyncio.gather(*lambda_tasks)
+                    lambda_tasks = []
+
+            # collect any remaining tasks in the context of the thread pool
+            await asyncio.gather(*lambda_tasks)
+
+
 if __name__ == "__main__":
 
     print()
@@ -266,23 +318,29 @@ if __name__ == "__main__":
     lambda_funcs = []
     for i in range(N_lambdas):
         event = {"i": i}
+        # event = {"action": "too-large"}
         payload = json.dumps(event).encode()
         func = AWSLambdaFunction(name="lambda_dev", payload=payload)
         lambda_funcs.append(func)
 
     asyncio.run(run_lambda_functions(lambda_funcs))
+    # # Note: a thread pool executor may not be more efficient than asyncio alone
+    # asyncio.run(run_lambda_function_thread_pool(lambda_funcs, n_tasks=N_lambdas))
 
     for func in lambda_funcs:
         assert response_success(func.response)
         # TODO: parse and gather all responses
         if N_lambdas < 5:
             print()
+            print("Params:")
             print(func.params)
-            print()
+            print("Response:")
             print(func.response)
-            print()
+            print("Content:")
             print(func.content)
-            print()
+            print("Error:")
+            print(func.error)
+            print("Logs")
             print(func.logs)
 
     end = time.perf_counter() - start

--- a/aio_aws/aio_aws_s3.py
+++ b/aio_aws/aio_aws_s3.py
@@ -150,7 +150,9 @@ from aio_aws.aio_aws_config import aio_aws_session
 from aio_aws.aio_aws_config import AioAWSConfig
 from aio_aws.aio_aws_config import jitter
 from aio_aws.aio_aws_config import response_success
-from aio_aws.logger import LOGGER
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/aio_aws/async_executor.py
+++ b/aio_aws/async_executor.py
@@ -70,7 +70,6 @@ using an :py:class:`.AsyncioExecutor`
 import asyncio
 import concurrent.futures
 import inspect
-import logging
 import random
 import threading
 import time
@@ -84,8 +83,9 @@ from typing import Iterator
 from typing import Optional
 from typing import Union
 
-LOGGER = logging.getLogger("async_executor")
-LOGGER.setLevel(logging.INFO)
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
 
 
 def loop_mgr(loop: asyncio.AbstractEventLoop):

--- a/aio_aws/logger.py
+++ b/aio_aws/logger.py
@@ -26,8 +26,14 @@ logging.Formatter.converter = time.gmtime
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 LOG_FORMAT = "[%(levelname)s]  %(asctime)s.%(msecs)03dZ  %(name)s:%(funcName)s:%(lineno)d  %(message)s"
 LOG_FORMATTER = logging.Formatter(LOG_FORMAT, "%Y-%m-%dT%H:%M:%S")
-handler = logging.StreamHandler(sys.stdout)
-handler.formatter = LOG_FORMATTER
-LOGGER = logging.getLogger("aio-aws")
-LOGGER.addHandler(handler)
-LOGGER.setLevel(LOG_LEVEL)
+HANDLER = logging.StreamHandler(sys.stdout)
+HANDLER.formatter = LOG_FORMATTER
+
+
+def get_logger(name: str = "aio-aws") -> logging.Logger:
+    logger = logging.getLogger(name)
+    if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
+        logger.addHandler(HANDLER)
+    logger.setLevel(LOG_LEVEL)
+    logger.propagate = False
+    return logger


### PR DESCRIPTION
Revise some lambda response handling and logging.

It should fix an error with logging errors:
```
--- Logging error ---
TypeError: not all arguments converted during string formatting
File "/opt/python/lib/python3.7/site-packages/aio_aws/aio_aws_lambda.py", line 175, in invoke
"AWS Lambda (%s) error: ", self.name, self.error
```