### PR TITLE
Aio batch jobs db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: python
 cache: pip
-python:
-- '3.7'
+
+jobs:
+  include:
+    - name: "Python 3.8 on Focal"
+      python: 3.8
+      dist: focal
+
+services:
+  - redis-server
 
 install:
   - python3 -m pip install -U pip
@@ -9,12 +16,9 @@ install:
   - source $HOME/.poetry/env
   - make init
 
-jobs:
-  include:
-  - stage: test
-    script:
-    - source $HOME/.poetry/env
-    - make test
+script:
+  - source $HOME/.poetry/env
+  - make test
 
 notifications:
   email:

--- a/aio_aws/aio_aws_batch_db.py
+++ b/aio_aws/aio_aws_batch_db.py
@@ -1,0 +1,341 @@
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Set
+
+import aioredis
+from aio_aws.aio_aws_batch import AWSBatchJob
+from aio_aws.logger import get_logger
+from aio_aws.uuid_utils import valid_uuid4
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass
+class AioAWSBatchDB:
+    """
+    AWS Batch job databases
+
+    The jobs and logs are kept in separate DBs so
+    that performance on the jobs_db is not compromised
+    by too much data from job logs.  This makes it possible
+    to use the jobs_db without capturing logs as well.
+
+    """
+
+    redis_url: str = "redis://localhost"
+
+    # TODO: use files to dump redis-db?
+    # #: a file used for dumping jobs-db
+    # jobs_db_file: str = "/tmp/aws_batch_jobs.json"
+    # #: a file used for dumping logs-db
+    # logs_db_file: str = "/tmp/aws_batch_logs.json"
+
+    def __post_init__(self):
+
+        # the jobs and logs are kept in separate DBs so
+        # that performance on the jobs_db is not compromised
+        # by too much data from job logs.
+
+        # Redis client bound to pool of connections (auto-reconnecting).
+        self.jobs_db = aioredis.from_url(
+            self.redis_url,
+            db=2,
+            encoding="utf-8",
+            decode_responses=True,
+            max_connections=10,
+        )
+        self.logs_db = aioredis.from_url(
+            self.redis_url,
+            db=4,
+            encoding="utf-8",
+            decode_responses=True,
+            max_connections=10,
+        )
+
+        # Lazy init for any asyncio instances
+        self._db_sem = None
+
+    @property
+    def db_semaphore(self) -> asyncio.Semaphore:
+        """A semaphore to limit requests to the db"""
+        if self._db_sem is None:
+            self._db_sem = asyncio.Semaphore(10)
+        return self._db_sem
+
+    @property
+    async def db_alive(self) -> bool:
+        try:
+            assert await self.jobs_db.ping() is True
+            assert await self.logs_db.ping() is True
+        except AssertionError:
+            return False
+        return True
+
+    @property
+    async def db_info(self) -> Dict:
+        info = {
+            "jobs": await self.jobs_db.info(),
+            "logs": await self.logs_db.info(),
+        }
+        LOGGER.debug("Using batch-jobs redis-db: %s", info)
+        return info
+
+    async def db_save(self):
+        assert await self.jobs_db.bgsave() is True
+        assert await self.logs_db.bgsave() is True
+
+    async def find_by_job_id(self, job_id: str) -> Optional[Dict]:
+        """
+        Find one job by the jobId
+
+        :param job_id: a batch jobId
+        :return: the job data or None
+        """
+        if job_id:
+            job_json = await self.jobs_db.get(job_id)
+            if job_json:
+                return json.loads(job_json)
+
+    async def find_by_job_name(self, job_name: str) -> List[Dict]:
+        """
+        Find any jobs matching the jobName
+
+        :param job_name: a batch jobName
+        :return: a list of dictionaries containing job data
+        """
+        jobs = []
+        if job_name:
+            job_ids = await self.jobs_db.get(job_name)
+            if job_ids:
+                # This should be a list of batch job-ids for a job name
+                job_ids = set(json.loads(job_ids))
+                for job_id in job_ids:
+                    job_dict = await self.find_by_job_id(job_id)
+                    if job_dict:
+                        jobs.append(job_dict)
+        return jobs
+
+    async def find_latest_job_name(self, job_name: str) -> Optional[AWSBatchJob]:
+        """
+        Find the latest job matching the jobName,
+        based on the "createdAt" time stamp.
+
+        :param job_name: a batch jobName
+        :return: the latest job record available
+        """
+        jobs_saved = await self.find_by_job_name(job_name)
+        if jobs_saved:
+            db_jobs = [AWSBatchJob(**job_dict) for job_dict in jobs_saved]
+            db_jobs = sorted(db_jobs, key=lambda j: j.created)
+            db_job = db_jobs[-1]
+            return db_job
+
+    async def remove_by_job_id(self, job_id: str) -> Optional[Dict]:
+        """
+        Remove any job matching the jobId
+
+        :param job_id: a batch jobId
+        :return: a deleted document
+        """
+        if job_id:
+            job_dict = await self.find_by_job_id(job_id)
+            if job_dict:
+                # TODO: use a transaction
+                # First try to remove this job-id from the job-name
+                job_name = job_dict["job_name"]
+                job_ids = await self.jobs_db.get(job_name)
+                if job_ids:
+                    # This should be a list of batch job-ids for a job name
+                    job_ids = set(json.loads(job_ids))
+                    if job_id in job_ids:
+                        job_ids.remove(job_id)
+                        if job_ids:
+                            await self.jobs_db.set(job_name, job_ids)
+                        else:
+                            # Don't save an empty set, delete the job-name entirely
+                            await self.jobs_db.delete(job_name)
+
+                await self.jobs_db.delete(job_id)
+                return job_dict
+
+    async def remove_by_job_name(self, job_name: str) -> Set[str]:
+        """
+        Remove any jobs matching the jobName
+
+        :param job_name: a batch jobName
+        :return: a set of deleted job-ids
+        """
+        job_ids = set()
+        if job_name:
+            job_ids = await self.jobs_db.get(job_name)
+            if not job_ids:
+                job_ids = set()
+            else:
+                job_ids = set(json.loads(job_ids))
+            await self.jobs_db.delete(*job_ids)
+            await self.jobs_db.delete(job_name)
+        return job_ids
+
+    async def save_job(self, job: AWSBatchJob) -> Optional[str]:
+        """
+        Insert or update a job (if it has a job_id)
+
+        :param job: an AWSBatchJob
+        :return: the jobId if the job is saved
+        """
+        if job.job_id is None:
+            LOGGER.error("FAIL to save_job without job_id")
+            return
+
+        # TODO: use a transaction
+        job_json = json.dumps(job.db_data)
+        response = await self.jobs_db.set(job.job_id, job_json)
+        LOGGER.debug(response)
+        if not response:
+            msg = f"FAIL to save_job with job_id: {job.job_id}"
+            LOGGER.error(msg)
+            raise RuntimeError(msg)
+
+        # Update the job-id set for the job-name
+        job_ids = await self.jobs_db.get(job.job_name)
+        if not job_ids:
+            job_ids = set()
+        else:
+            job_ids = set(json.loads(job_ids))
+        if job.job_id not in job_ids:
+            job_ids.add(job.job_id)
+            job_ids = json.dumps(list(job_ids))
+            await self.jobs_db.set(job.job_name, job_ids)
+
+        return job.job_id
+
+    async def find_job_logs(self, job_id: str) -> Optional[Dict]:
+        """
+        Find job logs by job_id
+
+        :param job_id: str
+        :return: job logs document
+        """
+        if job_id:
+            job_logs = await self.logs_db.get(job_id)
+            if job_logs:
+                return job_logs
+        LOGGER.error("FAIL to find_job_logs with job_id: %s", job_id)
+
+    async def save_job_logs(self, job: AWSBatchJob) -> List[int]:
+        """
+        Insert or update job logs (if the job has a job_id)
+
+        :param job: an AWSBatchJob
+        :return: a List[tinydb.database.Document.doc_id]
+        """
+        # TODO: update return data type and content
+        if job.job_id:
+            return await self.logs_db.set(job.job_id, job.db_logs_data)
+        LOGGER.error("FAIL to save_job_logs")
+
+    async def all_job_ids(self) -> Set[str]:
+        """
+        Find all jobId keys.
+        """
+        job_ids = set()
+        async for key in self.jobs_db.scan_iter():
+            if valid_uuid4(key):
+                job_ids.add(key)
+        return job_ids
+
+    async def find_jobs_to_run(self) -> List[AWSBatchJob]:
+        """
+        Find all jobs that have not SUCCEEDED.
+        """
+        jobs_outstanding = []
+        async for key in self.jobs_db.scan_iter():
+            if valid_uuid4(key):
+                job_dict = await self.find_by_job_id(key)
+                LOGGER.info(
+                    "AWS Batch job (%s:%s) has db status: %s",
+                    job_dict["job_name"],
+                    job_dict["job_id"],
+                    job_dict["status"],
+                )
+                if job_dict["job_id"] and job_dict["status"] == "SUCCEEDED":
+                    LOGGER.debug(job_dict["job_description"])
+                    continue
+
+                jobs_outstanding.append(AWSBatchJob(**job_dict))
+        return jobs_outstanding
+
+    async def jobs_to_run(self, jobs: List[AWSBatchJob]) -> List[AWSBatchJob]:
+        """
+        Use the job.job_name to find any jobs_db records and check the job status
+        on the latest submission of any job matching the job-name.  For any job that
+        has a matching job-name in the jobs_db, check whether the job has already run and
+        SUCCEEDED.  Any jobs that have already run and SUCCEEDED are not returned.
+
+        Return all jobs that have not run yet or have not SUCCEEDED.  Note that any
+        jobs subsequently input to the job-manager will not re-run if they already
+        have a job.job_id, those jobs will be monitored until complete.  To re-run
+        jobs that are returned from this filter function, first use `job.reset()`
+        before passing the jobs to the job-manager.
+
+        .. note::
+            The input jobs are not modified in any way in this function, i.e. there
+            are no updates from the jobs_db applied to the input jobs.
+
+            To recover jobs from the jobs_db, use
+            - :py:meth:`AWSBatchDB.find_jobs_to_run()`
+            - :py:meth:`AWSBatchDB.jobs_db.all()`
+        """
+        jobs_outstanding = []
+        for job in jobs:
+            # Avoid side-effects in this function:
+            # - treat the job as a read-only object
+            # - treat any jobs_db records as read-only objects
+            # - if a job is not saved, don't save it to jobs_db
+
+            # First check the job itself before checking the jobs_db
+            if job.job_id and job.status == "SUCCEEDED":
+                LOGGER.debug(job.job_description)
+                continue
+
+            db_job = await self.find_latest_job_name(job.job_name)
+            if db_job:
+                LOGGER.info(
+                    "AWS Batch job (%s:%s) has db status: %s",
+                    db_job.job_name,
+                    db_job.job_id,
+                    db_job.status,
+                )
+
+                if db_job.job_id and db_job.status == "SUCCEEDED":
+                    LOGGER.debug(db_job.job_description)
+                    continue
+
+            jobs_outstanding.append(job)
+
+        return jobs_outstanding
+
+    async def jobs_recovery(self, jobs: List[AWSBatchJob]) -> List[AWSBatchJob]:
+        """
+        Use the job.job_name to find any jobs_db records to recover job data.
+        """
+        jobs_recovered = []
+        for job in jobs:
+
+            db_job = await self.find_latest_job_name(job.job_name)
+            if db_job:
+                LOGGER.info(
+                    "AWS Batch job (%s:%s) recovered from db with status: %s",
+                    db_job.job_name,
+                    db_job.job_id,
+                    db_job.status,
+                )
+                jobs_recovered.append(db_job)
+            else:
+                jobs_recovered.append(job)
+
+        return jobs_recovered

--- a/aio_aws/aws_batch_db.py
+++ b/aio_aws/aws_batch_db.py
@@ -1,0 +1,280 @@
+# pylint: disable=bad-continuation
+
+# Copyright 2020 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AWS Batch DB
+============
+
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import List
+from typing import Optional
+
+import tinydb
+
+from aio_aws.aws_batch_models import AWSBatchJob
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+#: batch job startup pause (seconds)
+BATCH_STARTUP_PAUSE: float = 30
+
+
+@dataclass
+class AWSBatchDB:
+    """
+    AWS Batch job databases
+
+    The jobs and logs are kept in separate DBs so
+    that performance on the jobs_db is not compromised
+    by too much data from job logs.  This makes it possible
+    to use the jobs_db without capturing logs as well.
+
+    .. seealso:: https://tinydb.readthedocs.io/en/latest/
+    """
+
+    #: a file used for :py:class::`TinyDB(jobs_db_file)`
+    jobs_db_file: str = "/tmp/aws_batch_jobs.json"
+
+    #: a file used for :py:class::`TinyDB(logs_db_file)`
+    logs_db_file: str = "/tmp/aws_batch_logs.json"
+
+    def __post_init__(self):
+
+        tinydb.TinyDB.DEFAULT_TABLE = "aws-batch-jobs"
+        tinydb.TinyDB.DEFAULT_TABLE_KWARGS = {"cache_size": 0}
+
+        # the jobs and logs are kept in separate DBs so
+        # that performance on the jobs_db is not compromised
+        # by too much data from job logs.
+        self.jobs_db = tinydb.TinyDB(self.jobs_db_file)
+        self.logs_db = tinydb.TinyDB(self.logs_db_file)
+        LOGGER.info("Using batch-jobs-db file: %s", self.jobs_db_file)
+        LOGGER.info("Using batch-logs-db file: %s", self.logs_db_file)
+
+        # Lazy init for any asyncio instances
+        self._db_sem = None
+
+    @property
+    def db_semaphore(self) -> asyncio.Semaphore:
+        """A semaphore to limit requests to the db"""
+        if self._db_sem is None:
+            self._db_sem = asyncio.Semaphore()
+        return self._db_sem
+
+    def find_by_job_id(self, job_id: str) -> Optional[tinydb.database.Document]:
+        """
+        Find one job by the jobId
+
+        :param job_id: a batch jobId
+        :return: the :py:meth:`AWSBatchJob.job_data` or None
+        """
+        if job_id:
+            job_query = tinydb.Query()
+            db_result = self.jobs_db.get(job_query.job_id == job_id)
+            if db_result:
+                return db_result
+
+    def find_by_job_name(self, job_name: str) -> List[tinydb.database.Document]:
+        """
+        Find any jobs matching the jobName
+
+        :param job_name: a batch jobName
+        :return: a list of documents containing :py:meth:`AWSBatchJob.job_data`
+        """
+        if job_name:
+            job_query = tinydb.Query()
+            return self.jobs_db.search(job_query.job_name == job_name)
+
+    def find_latest_job_name(self, job_name: str) -> Optional[AWSBatchJob]:
+        """
+        Find the latest job matching the jobName,
+        based on the "createdAt" time stamp.
+
+        :param job_name: a batch jobName
+        :return: the latest job record available
+        """
+        jobs_saved = self.find_by_job_name(job_name)
+        if jobs_saved:
+            db_jobs = [AWSBatchJob(**job_doc) for job_doc in jobs_saved]
+            db_jobs = sorted(db_jobs, key=lambda j: j.created)
+            db_job = db_jobs[-1]
+            return db_job
+
+    def remove_by_job_id(self, job_id: str) -> Optional[tinydb.database.Document]:
+        """
+        Remove any job matching the jobId
+
+        :param job_id: a batch jobId
+        :return: a deleted document
+        """
+        if job_id:
+            job = self.find_by_job_id(job_id)
+            if job:
+                self.jobs_db.remove(doc_ids=[job.doc_id])
+                return job
+
+    def remove_by_job_name(self, job_name: str) -> List[tinydb.database.Document]:
+        """
+        Remove any jobs matching the jobName
+
+        :param job_name: a batch jobName
+        :return: a list of deleted documents
+        """
+        if job_name:
+            jobs_found = self.find_by_job_name(job_name)
+            if jobs_found:
+                docs = [doc.doc_id for doc in jobs_found]
+                self.jobs_db.remove(doc_ids=docs)
+            return jobs_found
+
+    def save_job(self, job: AWSBatchJob) -> List[int]:
+        """
+        Insert or update a job (if it has a job_id)
+
+        :param job: an AWSBatchJob
+        :return: a List[tinydb.database.Document.doc_id]
+        """
+        if job.job_id:
+            job_query = tinydb.Query()
+            return self.jobs_db.upsert(job.db_data, job_query.job_id == job.job_id)
+        else:
+            LOGGER.error("FAIL to save_job without job_id")
+
+    def find_job_logs(self, job_id: str) -> Optional[tinydb.database.Document]:
+        """
+        Find job logs by job_id
+
+        :param job_id: str
+        :return: a tinydb.database.Document with job logs
+        """
+        if job_id:
+            log_query = tinydb.Query()
+            db_result = self.logs_db.get(log_query.job_id == job_id)
+            if db_result:
+                return db_result
+        else:
+            LOGGER.error("FAIL to find_job_logs without job_id")
+
+    def save_job_logs(self, job: AWSBatchJob) -> List[int]:
+        """
+        Insert or update job logs (if the job has a job_id)
+
+        :param job: an AWSBatchJob
+        :return: a List[tinydb.database.Document.doc_id]
+        """
+        if job.job_id:
+            log_query = tinydb.Query()
+            return self.logs_db.upsert(job.db_logs_data, log_query.job_id == job.job_id)
+        else:
+            LOGGER.error("FAIL to save_job_logs without job_id")
+
+    def find_jobs_to_run(self) -> List[AWSBatchJob]:
+        """
+        Find all jobs that have not SUCCEEDED.  Note that any jobs handled
+        by the job-manager will not re-run if they have a job.job_id, those
+        jobs will be monitored until complete.
+        """
+        jobs = [AWSBatchJob(**job_doc) for job_doc in self.jobs_db.all()]
+        jobs_outstanding = []
+        for job in jobs:
+            LOGGER.info(
+                "AWS Batch job (%s:%s) has db status: %s",
+                job.job_name,
+                job.job_id,
+                job.status,
+            )
+            if job.job_id and job.status == "SUCCEEDED":
+                LOGGER.debug(job.job_description)
+                continue
+
+            jobs_outstanding.append(job)
+
+        return jobs_outstanding
+
+    def jobs_to_run(self, jobs: List[AWSBatchJob]) -> List[AWSBatchJob]:
+        """
+        Use the job.job_name to find any jobs_db records and check the job status
+        on the latest submission of any job matching the job-name.  For any job that
+        has a matching job-name in the jobs_db, check whether the job has already run and
+        SUCCEEDED.  Any jobs that have already run and SUCCEEDED are not returned.
+
+        Return all jobs that have not run yet or have not SUCCEEDED.  Note that any
+        jobs subsequently input to the job-manager will not re-run if they already
+        have a job.job_id, those jobs will be monitored until complete.  To re-run
+        jobs that are returned from this filter function, first use `job.reset()`
+        before passing the jobs to the job-manager.
+
+        .. note::
+            The input jobs are not modified in any way in this function, i.e. there
+            are no updates from the jobs_db applied to the input jobs.
+
+            To recover jobs from the jobs_db, use
+            - :py:meth:`AWSBatchDB.find_jobs_to_run()`
+            - :py:meth:`AWSBatchDB.jobs_db.all()`
+        """
+        jobs_outstanding = []
+        for job in jobs:
+            # Avoid side-effects in this function:
+            # - treat the job as a read-only object
+            # - treat any jobs_db records as read-only objects
+            # - if a job is not saved, don't save it to jobs_db
+
+            # First check the job itself before checking the jobs_db
+            if job.job_id and job.status == "SUCCEEDED":
+                LOGGER.debug(job.job_description)
+                continue
+
+            db_job = self.find_latest_job_name(job.job_name)
+            if db_job:
+                LOGGER.info(
+                    "AWS Batch job (%s:%s) has db status: %s",
+                    db_job.job_name,
+                    db_job.job_id,
+                    db_job.status,
+                )
+
+                if db_job.job_id and db_job.status == "SUCCEEDED":
+                    LOGGER.debug(db_job.job_description)
+                    continue
+
+            jobs_outstanding.append(job)
+
+        return jobs_outstanding
+
+    def jobs_recovery(self, jobs: List[AWSBatchJob]) -> List[AWSBatchJob]:
+        """
+        Use the job.job_name to find any jobs_db records to recover job data.
+        """
+        jobs_recovered = []
+        for job in jobs:
+
+            db_job = self.find_latest_job_name(job.job_name)
+            if db_job:
+                LOGGER.info(
+                    "AWS Batch job (%s:%s) recovered from db with status: %s",
+                    db_job.job_name,
+                    db_job.job_id,
+                    db_job.status,
+                )
+                jobs_recovered.append(db_job)
+            else:
+                jobs_recovered.append(job)
+
+        return jobs_recovered

--- a/aio_aws/aws_batch_models.py
+++ b/aio_aws/aws_batch_models.py
@@ -1,0 +1,220 @@
+#! /usr/bin/env python3
+# pylint: disable=bad-continuation
+
+# Copyright 2020 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+AioAWS Batch Job
+================
+
+Batch Job metadata models.
+
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from aio_aws.logger import get_logger
+
+LOGGER = get_logger(__name__)
+
+#: batch job startup pause (seconds)
+BATCH_STARTUP_PAUSE: float = 30
+
+
+@dataclass
+class AWSBatchJobDescription:
+    jobName: str = None
+    jobId: str = None
+    jobQueue: str = None
+    status: str = None
+    attempts: List[Dict] = None
+    statusReason: str = None
+    createdAt: int = None
+    startedAt: int = None
+    stoppedAt: int = None
+    dependsOn: List[str] = None
+    jobDefinition: str = None
+    parameters: Dict = None
+    container: Dict = None
+    timeout: Dict = None
+
+
+@dataclass
+class AWSBatchJob:
+    """
+    AWS Batch job
+
+    Creating an AWSBatchJob instance does not run anything, it's simply
+    a dataclass to retain and track job attributes.  There are no instance
+    methods to run a job, the instances are passed to async coroutine functions.
+
+    Replace 'command' with 'container_overrides' dict for more options;
+    do not use 'command' together with 'container_overrides', or understand
+    that the construction will update the `container_overrides['command']`
+    when the `command is not None`.
+
+    :param job_name: A job jobName (truncated to 128 characters).
+    :param job_definition: A job job_definition.
+    :param job_queue: A batch queue.
+    :param command: A container command.
+    :param depends_on: list of dictionaries like:
+
+        .. code-block::
+
+            [
+              {'jobId': 'abc123', ['type': 'N_TO_N' | 'SEQUENTIAL'] },
+            ]
+
+        type is optional, used only for job arrays
+
+    :param container_overrides: a dictionary of container overrides.
+        Overrides include 'vcpus', 'memory', 'instanceType',
+        'environment', and 'resourceRequirements'. If the `command`
+        parameter is defined, it overrides the `container_overrides['command']`
+
+    :param max_tries: an optional limit to the number of job retries, which
+        can apply in the job-manager function to any job with a SPOT failure
+        only and it applies regardless of the job-definition settings.
+
+    .. seealso::
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
+    """
+
+    STATUSES = [
+        "SUBMITTED",
+        "PENDING",
+        "RUNNABLE",
+        "STARTING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+    ]
+
+    job_name: str
+    job_queue: str
+    job_definition: str
+    command: List[str] = None
+    depends_on: List[Dict] = None
+    container_overrides: Dict = None
+    job_id: Optional[str] = None
+    status: Optional[str] = None
+    job_tries: List[str] = None
+    num_tries: int = 0
+    max_tries: int = 4
+    job_submission: Optional[Dict] = None
+    job_description: Optional[Dict] = None
+    logs: Optional[List[Dict]] = None
+
+    def __post_init__(self):
+
+        self.job_name = self.job_name[:128]
+
+        if self.job_tries is None:
+            self.job_tries = []
+
+        if self.depends_on is None:
+            self.depends_on = []
+
+        if self.container_overrides is None:
+            self.container_overrides = {}
+
+        if self.command:
+            self.container_overrides.update({"command": self.command})
+
+    @property
+    def params(self):
+        """AWS Batch parameters for job submission"""
+        return {
+            "jobName": self.job_name,
+            "jobQueue": self.job_queue,
+            "jobDefinition": self.job_definition,
+            "containerOverrides": self.container_overrides,
+            "dependsOn": self.depends_on,
+        }
+
+    @property
+    def db_data(self) -> Dict:
+        """AWS Batch job data for state machine persistence"""
+        # The job.logs are NOT included here, by design.
+        return {
+            "job_id": self.job_id,
+            "job_name": self.job_name,
+            "job_queue": self.job_queue,
+            "job_definition": self.job_definition,
+            "job_submission": self.job_submission,
+            "job_description": self.job_description,
+            "container_overrides": self.container_overrides,
+            "command": self.command,
+            "depends_on": self.depends_on,
+            "status": self.status,
+            "job_tries": self.job_tries,
+            "num_tries": self.num_tries,
+            "max_tries": self.max_tries,
+        }
+
+    @property
+    def db_logs_data(self) -> Optional[Dict]:
+        """AWS Batch job with logs persistence"""
+        if self.logs:
+            data = self.db_data
+            data["logs"] = self.logs
+            return data
+
+    def reset(self):
+        """Clear the job_id and all related job data"""
+        self.job_id = None
+        self.job_description = None
+        self.job_submission = None
+        self.status = None
+        self.logs = None
+
+    @property
+    def created(self) -> Optional[int]:
+        if self.job_description:
+            return self.job_description.get("createdAt")
+
+    @property
+    def started(self) -> Optional[int]:
+        if self.job_description:
+            return self.job_description.get("startedAt")
+
+    @property
+    def stopped(self) -> Optional[int]:
+        if self.job_description:
+            return self.job_description.get("stoppedAt")
+
+    @property
+    def elapsed(self) -> Optional[int]:
+        created = self.created
+        stopped = self.stopped
+        if stopped and created:
+            return stopped - created
+
+    @property
+    def runtime(self) -> Optional[int]:
+        started = self.started
+        stopped = self.stopped
+        if started and stopped:
+            return stopped - started
+
+    @property
+    def spinup(self) -> Optional[int]:
+        created = self.created
+        started = self.started
+        if started and created:
+            return started - created

--- a/aio_aws/uuid_utils.py
+++ b/aio_aws/uuid_utils.py
@@ -1,0 +1,71 @@
+import concurrent.futures
+import re
+from typing import Iterator
+from typing import List
+from uuid import uuid4
+
+# regex patterns are from
+# https://stackoverflow.com/questions/11384589/what-is-the-correct-regex-for-matching-values-generated-by-uuid-uuid4-hex
+
+RE_UUID4 = re.compile(
+    r"^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z", re.I
+)
+
+RE_UUID4_HEX = re.compile(r"[0-9a-f]{32}\Z", re.I)
+
+
+def get_uuid(_: int = None) -> str:
+    """
+    Get a UUID as a string value
+    """
+    return str(uuid4())
+
+
+def get_hex_uuid(_: int = None) -> str:
+    """
+    Get a UUID as a hex string value
+    """
+    # Ensure that a uuid4().hex returns a validated UUID.
+    return uuid4().hex
+
+
+def valid_uuid4(uuid):
+    match = RE_UUID4.match(uuid)
+    return bool(match)
+
+
+def valid_hex_uuid4(uuid):
+    match = RE_UUID4_HEX.match(uuid)
+    return bool(match)
+
+
+def get_uuids(n_uuids: int) -> List[str]:
+    """
+    Get a list of UUIDs
+    """
+    return list(generate_uuids(n_uuids))
+
+
+def generate_uuids(n_uuids: int) -> Iterator[str]:
+    """
+    Generate an iterator of UUIDs
+    """
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        uuids = executor.map(get_uuid, range(n_uuids))
+        return uuids
+
+
+def get_hex_uuids(n_uuids: int) -> List[str]:
+    """
+    Get a list of UUIDs
+    """
+    return list(generate_hex_uuids(n_uuids))
+
+
+def generate_hex_uuids(n_uuids: int) -> Iterator[str]:
+    """
+    Generate an iterator of UUIDs
+    """
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        uuids = executor.map(get_hex_uuid, range(n_uuids))
+        return uuids

--- a/poetry.lock
+++ b/poetry.lock
@@ -67,15 +67,19 @@ sa = ["sqlalchemy (>=1.0)"]
 
 [[package]]
 name = "aioredis"
-version = "1.3.1"
+version = "2.0.0"
 description = "asyncio (PEP 3156) Redis support"
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 async-timeout = "*"
-hiredis = "*"
+hiredis = {version = ">=1.0", optional = true, markers = "implementation_name == \"cpython\" and extra == \"hiredis\""}
+typing-extensions = "*"
+
+[package.extras]
+hiredis = ["hiredis (>=1.0)"]
 
 [[package]]
 name = "aiosqlite"
@@ -114,7 +118,7 @@ python-versions = "*"
 
 [[package]]
 name = "astroid"
-version = "2.7.2"
+version = "2.7.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "main"
 optional = false
@@ -215,14 +219,14 @@ wrapt = "*"
 
 [[package]]
 name = "awscli"
-version = "1.20.28"
+version = "1.20.38"
 description = "Universal Command Line Environment for AWS."
 category = "main"
 optional = true
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = "1.21.28"
+botocore = "1.21.38"
 colorama = ">=0.2.5,<0.4.4"
 docutils = ">=0.10,<0.16"
 PyYAML = ">=3.10,<5.5"
@@ -287,7 +291,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "bleach"
-version = "4.0.0"
+version = "4.1.0"
 description = "An easy safelist-based HTML-sanitizing tool."
 category = "dev"
 optional = false
@@ -308,14 +312,14 @@ python-versions = "*"
 
 [[package]]
 name = "boto3"
-version = "1.18.28"
+version = "1.18.38"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.6"
 
 [package.dependencies]
-botocore = ">=1.21.28,<1.22.0"
+botocore = ">=1.21.38,<1.22.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
 
@@ -324,7 +328,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.21.28"
+version = "1.21.38"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -359,7 +363,7 @@ pycparser = "*"
 
 [[package]]
 name = "cfgv"
-version = "3.3.0"
+version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
 category = "dev"
 optional = false
@@ -367,7 +371,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "cfn-lint"
-version = "0.53.0"
+version = "0.54.0"
 description = "Checks CloudFormation templates for practices and behaviour that could potentially be improved"
 category = "dev"
 optional = false
@@ -464,7 +468,7 @@ test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pret
 
 [[package]]
 name = "databases"
-version = "0.4.3"
+version = "0.5.1"
 description = "Async database support for Python."
 category = "main"
 optional = true
@@ -474,7 +478,7 @@ python-versions = ">=3.6"
 aiomysql = {version = "*", optional = true, markers = "extra == \"mysql\""}
 aiosqlite = {version = "*", optional = true, markers = "extra == \"sqlite\""}
 asyncpg = {version = "*", optional = true, markers = "extra == \"postgresql\""}
-sqlalchemy = "<1.4"
+sqlalchemy = ">=1.4,<1.5"
 
 [package.extras]
 mysql = ["aiomysql"]
@@ -516,7 +520,7 @@ stevedore = "*"
 
 [[package]]
 name = "docker"
-version = "5.0.0"
+version = "5.0.2"
 description = "A Python library for the Docker Engine API."
 category = "dev"
 optional = false
@@ -641,6 +645,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "greenlet"
+version = "1.1.1"
+description = "Lightweight in-process concurrent programming"
+category = "main"
+optional = true
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[package.extras]
+docs = ["sphinx"]
+
+[[package]]
 name = "hiredis"
 version = "2.0.0"
 description = "Python wrapper for hiredis"
@@ -677,9 +692,9 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.6.4"
+version = "4.8.1"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -715,7 +730,7 @@ toml = {version = ">=0.10.2", markers = "python_version > \"3.6\""}
 
 [[package]]
 name = "ipython"
-version = "7.26.0"
+version = "7.27.0"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = false
@@ -744,14 +759,6 @@ notebook = ["notebook", "ipywidgets"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.17)"]
-
-[[package]]
-name = "ipython-genutils"
-version = "0.2.0"
-description = "Vestigial utilities from IPython"
-category = "main"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "isort"
@@ -928,7 +935,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
 name = "matplotlib-inline"
-version = "0.1.2"
+version = "0.1.3"
 description = "Inline Matplotlib backend for Jupyter"
 category = "main"
 optional = false
@@ -968,7 +975,7 @@ test = ["pytest (<5.4)", "pytest-cov"]
 
 [[package]]
 name = "more-itertools"
-version = "8.8.0"
+version = "8.9.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
@@ -1169,7 +1176,7 @@ testing = ["nose", "coverage"]
 
 [[package]]
 name = "platformdirs"
-version = "2.2.0"
+version = "2.3.0"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
@@ -1181,21 +1188,22 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 
 [[package]]
 name = "pluggy"
-version = "0.13.1"
+version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.14.0"
+version = "2.15.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -1374,7 +1382,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pytest"
-version = "6.2.4"
+version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -1387,7 +1395,7 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0.0a1"
+pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 toml = "*"
 
@@ -1678,7 +1686,7 @@ md = ["cmarkgfm (>=0.2.0)"]
 
 [[package]]
 name = "regex"
-version = "2021.8.21"
+version = "2021.8.28"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -1974,23 +1982,35 @@ test = ["pytest"]
 
 [[package]]
 name = "sqlalchemy"
-version = "1.3.24"
+version = "1.4.23"
 description = "Database Abstraction Library"
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+
+[package.dependencies]
+greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and platform_machine in \"x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
+aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
+aiosqlite = ["greenlet (!=0.4.17)", "aiosqlite"]
+asyncio = ["greenlet (!=0.4.17)"]
+mariadb_connector = ["mariadb (>=1.0.1)"]
 mssql = ["pyodbc"]
 mssql_pymssql = ["pymssql"]
 mssql_pyodbc = ["pyodbc"]
-mysql = ["mysqlclient"]
-oracle = ["cx-oracle"]
-postgresql = ["psycopg2"]
-postgresql_pg8000 = ["pg8000 (<1.16.6)"]
+mypy = ["sqlalchemy2-stubs", "mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0,<2)", "mysqlclient (>=1.4.0)"]
+mysql_connector = ["mysqlconnector"]
+oracle = ["cx_oracle (>=7,<8)", "cx_oracle (>=7)"]
+postgresql = ["psycopg2 (>=2.7)"]
+postgresql_asyncpg = ["greenlet (!=0.4.17)", "asyncpg"]
+postgresql_pg8000 = ["pg8000 (>=1.16.6)"]
 postgresql_psycopg2binary = ["psycopg2-binary"]
 postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql (<1)", "pymysql"]
+sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sshpubkeys"
@@ -2076,14 +2096,11 @@ telegram = ["requests"]
 
 [[package]]
 name = "traitlets"
-version = "5.0.5"
+version = "5.1.0"
 description = "Traitlets Python configuration system"
 category = "main"
 optional = false
 python-versions = ">=3.7"
-
-[package.dependencies]
-ipython-genutils = "*"
 
 [package.extras]
 test = ["pytest"]
@@ -2117,7 +2134,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
+version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
@@ -2125,11 +2142,11 @@ python-versions = "*"
 
 [[package]]
 name = "unidecode"
-version = "1.2.0"
+version = "1.3.0"
 description = "ASCII transliterations of Unicode text"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.5"
 
 [[package]]
 name = "urllib3"
@@ -2258,7 +2275,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -2267,14 +2284,16 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
+aioredis = ["aioredis"]
 all = ["aioredis", "databases"]
 awscli = ["awscli"]
+databases = ["databases"]
 docs = ["Sphinx", "sphinx-autoapi", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "ipython"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8d1f8178700b2378b077fba5c403bfc35b98479d2eceea7b6caeb98a496d2abe"
+content-hash = "f149074fe201e9fc00e909ba86e4daf6d17456550d4247c88b209f1edfbbc918"
 
 [metadata.files]
 aio-botocore = [
@@ -2333,8 +2352,8 @@ aiomysql = [
     {file = "aiomysql-0.0.21.tar.gz", hash = "sha256:811569c0db118dd2685f0878f5cebf17a11e89a995fa14261d5fa0254113842c"},
 ]
 aioredis = [
-    {file = "aioredis-1.3.1-py3-none-any.whl", hash = "sha256:b61808d7e97b7cd5a92ed574937a079c9387fdadd22bfbfa7ad2fd319ecc26e3"},
-    {file = "aioredis-1.3.1.tar.gz", hash = "sha256:15f8af30b044c771aee6787e5ec24694c048184c7b9e54c3b60c750a4b93273a"},
+    {file = "aioredis-2.0.0-py3-none-any.whl", hash = "sha256:9921d68a3df5c5cdb0d5b49ad4fc88a4cfdd60c108325df4f0066e8410c55ffb"},
+    {file = "aioredis-2.0.0.tar.gz", hash = "sha256:3a2de4b614e6a5f8e104238924294dc4e811aefbe17ddf52c04a93cbf06e67db"},
 ]
 aiosqlite = [
     {file = "aiosqlite-0.17.0-py3-none-any.whl", hash = "sha256:6c49dc6d3405929b1d08eeccc72306d3677503cc5e5e43771efc1e00232e8231"},
@@ -2353,8 +2372,8 @@ appnope = [
     {file = "appnope-0.1.2.tar.gz", hash = "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"},
 ]
 astroid = [
-    {file = "astroid-2.7.2-py3-none-any.whl", hash = "sha256:ecc50f9b3803ebf8ea19aa2c6df5622d8a5c31456a53c741d3be044d96ff0948"},
-    {file = "astroid-2.7.2.tar.gz", hash = "sha256:b6c2d75cd7c2982d09e7d41d70213e863b3ba34d3bd4014e08f167cee966e99e"},
+    {file = "astroid-2.7.3-py3-none-any.whl", hash = "sha256:dc1e8b28427d6bbef6b8842b18765ab58f558c42bb80540bd7648c98412af25e"},
+    {file = "astroid-2.7.3.tar.gz", hash = "sha256:3b680ce0419b8a771aba6190139a3998d14b413852506d99aff8dc2bf65ee67c"},
 ]
 async-timeout = [
     {file = "async-timeout-3.0.1.tar.gz", hash = "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"},
@@ -2397,8 +2416,8 @@ aws-xray-sdk = [
     {file = "aws_xray_sdk-2.8.0-py2.py3-none-any.whl", hash = "sha256:487e44a2e0b2a5b994f7db5fad3a8115f1ea238249117a119bce8ca2750661bd"},
 ]
 awscli = [
-    {file = "awscli-1.20.28-py3-none-any.whl", hash = "sha256:c1a7ad163b2db41a2833fdb1d2250486a11994dd46c68d461b99e01e8ca1b20d"},
-    {file = "awscli-1.20.28.tar.gz", hash = "sha256:fe008bb8c2fbb3c783f8d3557f4bc5f7d0b1fd032cb1fa9d9f1884c2eb881996"},
+    {file = "awscli-1.20.38-py3-none-any.whl", hash = "sha256:127173d3c587f6cf1de9265ca611afd8d559217ec8597644d166c189a2efb597"},
+    {file = "awscli-1.20.38.tar.gz", hash = "sha256:d471fdb7c20305a2b97d1883f34b52c8dd824e4cbd56b096359b5f4c99037488"},
 ]
 babel = [
     {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
@@ -2416,20 +2435,20 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 bleach = [
-    {file = "bleach-4.0.0-py2.py3-none-any.whl", hash = "sha256:c1685a132e6a9a38bf93752e5faab33a9517a6c0bb2f37b785e47bf253bdb51d"},
-    {file = "bleach-4.0.0.tar.gz", hash = "sha256:ffa9221c6ac29399cc50fcc33473366edd0cf8d5e2cbbbb63296dc327fb67cc8"},
+    {file = "bleach-4.1.0-py2.py3-none-any.whl", hash = "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"},
+    {file = "bleach-4.1.0.tar.gz", hash = "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da"},
 ]
 boto = [
     {file = "boto-2.49.0-py2.py3-none-any.whl", hash = "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8"},
     {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
 ]
 boto3 = [
-    {file = "boto3-1.18.28-py3-none-any.whl", hash = "sha256:dc5c6266cf0400314669fd23d1590c6895cd87c2d1d4254a4a31dc2f249e55c1"},
-    {file = "boto3-1.18.28.tar.gz", hash = "sha256:fcae01a690561755e7b87946a4685d29f3eb82a9671826fd210dd237c981c6dc"},
+    {file = "boto3-1.18.38-py3-none-any.whl", hash = "sha256:a7d831c65e0216ca5f1b06dbb6d8441e8f3926a7a535677bd257fed481cd2f7a"},
+    {file = "boto3-1.18.38.tar.gz", hash = "sha256:0d576a1b1288825a8ecac62e4eec0c4f6679c117e05575e7e0f66eb2f010450d"},
 ]
 botocore = [
-    {file = "botocore-1.21.28-py3-none-any.whl", hash = "sha256:60e57f2d680961c1babe55c2620ec08d26c5f969cc625a06dc2b62d59ec7a5eb"},
-    {file = "botocore-1.21.28.tar.gz", hash = "sha256:a4747637b74034298497b0e8bda4b196af730d2c44a6ab576501091ef5d0c887"},
+    {file = "botocore-1.21.38-py3-none-any.whl", hash = "sha256:beefe7dee5020e1f7cda84685131533324742529d8a5686ce959047e1b3e3928"},
+    {file = "botocore-1.21.38.tar.gz", hash = "sha256:5171b7db1c3346dd687ac0a195f69538c05ee0c2c26510de2019d0a0949297bf"},
 ]
 certifi = [
     {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
@@ -2483,12 +2502,12 @@ cffi = [
     {file = "cffi-1.14.6.tar.gz", hash = "sha256:c9a875ce9d7fe32887784274dd533c57909b7b1dcadcc128a2ac21331a9765dd"},
 ]
 cfgv = [
-    {file = "cfgv-3.3.0-py2.py3-none-any.whl", hash = "sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1"},
-    {file = "cfgv-3.3.0.tar.gz", hash = "sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1"},
+    {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 cfn-lint = [
-    {file = "cfn-lint-0.53.0.tar.gz", hash = "sha256:b7f5964842f7a44c5af9c61d64308dc4bcb718cf5de5428781d5564e9663463d"},
-    {file = "cfn_lint-0.53.0-py3-none-any.whl", hash = "sha256:d17359e3ca9477eccaea700fac4bf028f5bc368a338c017adde5187f2691cab8"},
+    {file = "cfn-lint-0.54.0.tar.gz", hash = "sha256:8a685b539e87fedac1f179d158bf07da63799c03ebb24e381795381869df03d0"},
+    {file = "cfn_lint-0.54.0-py3-none-any.whl", hash = "sha256:295871dd328912b2fb6e46548a4e690b9e141488963ce2634eb45992abdf383c"},
 ]
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
@@ -2632,8 +2651,8 @@ cryptography = [
     {file = "cryptography-3.4.8.tar.gz", hash = "sha256:94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c"},
 ]
 databases = [
-    {file = "databases-0.4.3-py3-none-any.whl", hash = "sha256:f82b02c28fdddf7ffe7ee1945f5abef44d687ba97b9a1c81492c7f035d4c90e6"},
-    {file = "databases-0.4.3.tar.gz", hash = "sha256:1521db7f6d3c581ff81b3552e130b27a13aefea2a57295e65738081831137afc"},
+    {file = "databases-0.5.1-py3-none-any.whl", hash = "sha256:52e3947e51b782ef1a01612b19fb2d5deedea8c4a36d790defc422509f861ec2"},
+    {file = "databases-0.5.1.tar.gz", hash = "sha256:cf0486f09bc610dfc10f68544cb2e426f2658ab8bfac051ffb2aa9ed374308ad"},
 ]
 decorator = [
     {file = "decorator-5.0.9-py3-none-any.whl", hash = "sha256:6e5c199c16f7a9f0e3a61a4a54b3d27e7dad0dbdde92b944426cb20914376323"},
@@ -2648,8 +2667,8 @@ doc8 = [
     {file = "doc8-0.8.1.tar.gz", hash = "sha256:4d1df12598807cf08ffa9a1d5ef42d229ee0de42519da01b768ff27211082c12"},
 ]
 docker = [
-    {file = "docker-5.0.0-py2.py3-none-any.whl", hash = "sha256:fc961d622160e8021c10d1bcabc388c57d55fb1f917175afbe24af442e6879bd"},
-    {file = "docker-5.0.0.tar.gz", hash = "sha256:3e8bc47534e0ca9331d72c32f2881bb13b93ded0bcdeab3c833fb7cf61c0a9a5"},
+    {file = "docker-5.0.2-py2.py3-none-any.whl", hash = "sha256:9b17f0723d83c1f3418d2aa17bf90b24dbe97deda06208dd4262fa30a6ee87eb"},
+    {file = "docker-5.0.2.tar.gz", hash = "sha256:21ec4998e90dff7a7aaaa098ca8d839c7de412b89e6f6c30908372d58fecf663"},
 ]
 docutils = [
     {file = "docutils-0.15.2-py2-none-any.whl", hash = "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827"},
@@ -2689,6 +2708,58 @@ future = [
 ]
 gprof2dot = [
     {file = "gprof2dot-2021.2.21.tar.gz", hash = "sha256:1223189383b53dcc8ecfd45787ac48c0ed7b4dbc16ee8b88695d053eea1acabf"},
+]
+greenlet = [
+    {file = "greenlet-1.1.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:476ba9435afaead4382fbab8f1882f75e3fb2285c35c9285abb3dd30237f9142"},
+    {file = "greenlet-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:44556302c0ab376e37939fd0058e1f0db2e769580d340fb03b01678d1ff25f68"},
+    {file = "greenlet-1.1.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:40abb7fec4f6294225d2b5464bb6d9552050ded14a7516588d6f010e7e366dcc"},
+    {file = "greenlet-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:a11b6199a0b9dc868990456a2667167d0ba096c5224f6258e452bfbe5a9742c5"},
+    {file = "greenlet-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e22a82d2b416d9227a500c6860cf13e74060cf10e7daf6695cbf4e6a94e0eee4"},
+    {file = "greenlet-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bad269e442f1b7ffa3fa8820b3c3aa66f02a9f9455b5ba2db5a6f9eea96f56de"},
+    {file = "greenlet-1.1.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:8ddb38fb6ad96c2ef7468ff73ba5c6876b63b664eebb2c919c224261ae5e8378"},
+    {file = "greenlet-1.1.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:84782c80a433d87530ae3f4b9ed58d4a57317d9918dfcc6a59115fa2d8731f2c"},
+    {file = "greenlet-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac991947ca6533ada4ce7095f0e28fe25d5b2f3266ad5b983ed4201e61596acf"},
+    {file = "greenlet-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5317701c7ce167205c0569c10abc4bd01c7f4cf93f642c39f2ce975fa9b78a3c"},
+    {file = "greenlet-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4870b018ca685ff573edd56b93f00a122f279640732bb52ce3a62b73ee5c4a92"},
+    {file = "greenlet-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:990e0f5e64bcbc6bdbd03774ecb72496224d13b664aa03afd1f9b171a3269272"},
+    {file = "greenlet-1.1.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:a414f8e14aa7bacfe1578f17c11d977e637d25383b6210587c29210af995ef04"},
+    {file = "greenlet-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e02780da03f84a671bb4205c5968c120f18df081236d7b5462b380fd4f0b497b"},
+    {file = "greenlet-1.1.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:dfcb5a4056e161307d103bc013478892cfd919f1262c2bb8703220adcb986362"},
+    {file = "greenlet-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:655ab836324a473d4cd8cf231a2d6f283ed71ed77037679da554e38e606a7117"},
+    {file = "greenlet-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:6ce9d0784c3c79f3e5c5c9c9517bbb6c7e8aa12372a5ea95197b8a99402aa0e6"},
+    {file = "greenlet-1.1.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:3fc6a447735749d651d8919da49aab03c434a300e9f0af1c886d560405840fd1"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8039f5fe8030c43cd1732d9a234fdcbf4916fcc32e21745ca62e75023e4d4649"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fddfb31aa2ac550b938d952bca8a87f1db0f8dc930ffa14ce05b5c08d27e7fd1"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b97a807437b81f90f85022a9dcfd527deea38368a3979ccb49d93c9198b2c722"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cf31e894dabb077a35bbe6963285d4515a387ff657bd25b0530c7168e48f167f"},
+    {file = "greenlet-1.1.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4eae94de9924bbb4d24960185363e614b1b62ff797c23dc3c8a7c75bbb8d187e"},
+    {file = "greenlet-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:c1862f9f1031b1dee3ff00f1027fcd098ffc82120f43041fe67804b464bbd8a7"},
+    {file = "greenlet-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:9b02e6039eafd75e029d8c58b7b1f3e450ca563ef1fe21c7e3e40b9936c8d03e"},
+    {file = "greenlet-1.1.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:84488516639c3c5e5c0e52f311fff94ebc45b56788c2a3bfe9cf8e75670f4de3"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3f8fc59bc5d64fa41f58b0029794f474223693fd00016b29f4e176b3ee2cfd9f"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3e594015a2349ec6dcceda9aca29da8dc89e85b56825b7d1f138a3f6bb79dd4c"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e41f72f225192d5d4df81dad2974a8943b0f2d664a2a5cfccdf5a01506f5523c"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:75ff270fd05125dce3303e9216ccddc541a9e072d4fc764a9276d44dee87242b"},
+    {file = "greenlet-1.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cde7ee190196cbdc078511f4df0be367af85636b84d8be32230f4871b960687"},
+    {file = "greenlet-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:f253dad38605486a4590f9368ecbace95865fea0f2b66615d121ac91fd1a1563"},
+    {file = "greenlet-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a91ee268f059583176c2c8b012a9fce7e49ca6b333a12bbc2dd01fc1a9783885"},
+    {file = "greenlet-1.1.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:34e6675167a238bede724ee60fe0550709e95adaff6a36bcc97006c365290384"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bf3725d79b1ceb19e83fb1aed44095518c0fcff88fba06a76c0891cfd1f36837"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5c3b735ccf8fc8048664ee415f8af5a3a018cc92010a0d7195395059b4b39b7d"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2002a59453858c7f3404690ae80f10c924a39f45f6095f18a985a1234c37334"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04e1849c88aa56584d4a0a6e36af5ec7cc37993fdc1fda72b56aa1394a92ded3"},
+    {file = "greenlet-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8d4ed48eed7414ccb2aaaecbc733ed2a84c299714eae3f0f48db085342d5629"},
+    {file = "greenlet-1.1.1-cp38-cp38-win32.whl", hash = "sha256:2f89d74b4f423e756a018832cd7a0a571e0a31b9ca59323b77ce5f15a437629b"},
+    {file = "greenlet-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:d15cb6f8706678dc47fb4e4f8b339937b04eda48a0af1cca95f180db552e7663"},
+    {file = "greenlet-1.1.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b050dbb96216db273b56f0e5960959c2b4cb679fe1e58a0c3906fa0a60c00662"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e0696525500bc8aa12eae654095d2260db4dc95d5c35af2b486eae1bf914ccd"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:07e6d88242e09b399682b39f8dfa1e7e6eca66b305de1ff74ed9eb1a7d8e539c"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98b491976ed656be9445b79bc57ed21decf08a01aaaf5fdabf07c98c108111f6"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e72db813c28906cdc59bd0da7c325d9b82aa0b0543014059c34c8c4ad20e16"},
+    {file = "greenlet-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:090126004c8ab9cd0787e2acf63d79e80ab41a18f57d6448225bbfcba475034f"},
+    {file = "greenlet-1.1.1-cp39-cp39-win32.whl", hash = "sha256:1796f2c283faab2b71c67e9b9aefb3f201fdfbee5cb55001f5ffce9125f63a45"},
+    {file = "greenlet-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:4adaf53ace289ced90797d92d767d37e7cdc29f13bd3830c3f0a561277a4ae83"},
+    {file = "greenlet-1.1.1.tar.gz", hash = "sha256:c0f22774cd8294078bdf7392ac73cf00bfa1e5e0ed644bd064fdabc5f2a2f481"},
 ]
 hiredis = [
     {file = "hiredis-2.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b4c8b0bc5841e578d5fb32a16e0c305359b987b850a06964bd5a62739d688048"},
@@ -2746,8 +2817,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.6.4-py3-none-any.whl", hash = "sha256:ed5157fef23a4bc4594615a0dd8eba94b2bb36bf2a343fa3d8bb2fa0a62a99d5"},
-    {file = "importlib_metadata-4.6.4.tar.gz", hash = "sha256:7b30a78db2922d78a6f47fb30683156a14f3c6aa5cc23f77cc8967e9ab2d002f"},
+    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
+    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -2757,12 +2828,8 @@ ipdb = [
     {file = "ipdb-0.13.9.tar.gz", hash = "sha256:951bd9a64731c444fd907a5ce268543020086a697f6be08f7cc2c9a752a278c5"},
 ]
 ipython = [
-    {file = "ipython-7.26.0-py3-none-any.whl", hash = "sha256:892743b65c21ed72b806a3a602cca408520b3200b89d1924f4b3d2cdb3692362"},
-    {file = "ipython-7.26.0.tar.gz", hash = "sha256:0cff04bb042800129348701f7bd68a430a844e8fb193979c08f6c99f28bb735e"},
-]
-ipython-genutils = [
-    {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
-    {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
+    {file = "ipython-7.27.0-py3-none-any.whl", hash = "sha256:75b5e060a3417cf64f138e0bb78e58512742c57dc29db5a5058a2b1f0c10df02"},
+    {file = "ipython-7.27.0.tar.gz", hash = "sha256:58b55ebfdfa260dad10d509702dc2857cb25ad82609506b070cf2d7b7df5af13"},
 ]
 isort = [
     {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
@@ -2893,8 +2960,8 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 matplotlib-inline = [
-    {file = "matplotlib-inline-0.1.2.tar.gz", hash = "sha256:f41d5ff73c9f5385775d5c0bc13b424535c8402fe70ea8210f93e11f3683993e"},
-    {file = "matplotlib_inline-0.1.2-py3-none-any.whl", hash = "sha256:5cf1176f554abb4fa98cb362aa2b55c500147e4bdbb07e3fda359143e1da0811"},
+    {file = "matplotlib-inline-0.1.3.tar.gz", hash = "sha256:a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee"},
+    {file = "matplotlib_inline-0.1.3-py3-none-any.whl", hash = "sha256:aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -2909,8 +2976,8 @@ mock = [
     {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.8.0.tar.gz", hash = "sha256:83f0308e05477c68f56ea3a888172c78ed5d5b3c282addb67508e7ba6c8f813a"},
-    {file = "more_itertools-8.8.0-py3-none-any.whl", hash = "sha256:2cf89ec599962f2ddc4d568a05defc40e0a587fbc10d5989713638864c36be4d"},
+    {file = "more-itertools-8.9.0.tar.gz", hash = "sha256:8c746e0d09871661520da4f1241ba6b908dc903839733c8203b552cffaf173bd"},
+    {file = "more_itertools-8.9.0-py3-none-any.whl", hash = "sha256:70401259e46e216056367a0a6034ee3d3f95e0bf59d3aa6a4eb77837171ed996"},
 ]
 moto = [
     {file = "moto-1.3.16-py2.py3-none-any.whl", hash = "sha256:f51903b6b532f6c887b111b3343f6925b77eef0505a914138d98290cf3526df9"},
@@ -3021,16 +3088,16 @@ pkginfo = [
     {file = "pkginfo-1.7.1.tar.gz", hash = "sha256:e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.2.0-py3-none-any.whl", hash = "sha256:4666d822218db6a262bdfdc9c39d21f23b4cfdb08af331a81e92751daf6c866c"},
-    {file = "platformdirs-2.2.0.tar.gz", hash = "sha256:632daad3ab546bd8e6af0537d09805cec458dce201bccfe23012df73332e181e"},
+    {file = "platformdirs-2.3.0-py3-none-any.whl", hash = "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"},
+    {file = "platformdirs-2.3.0.tar.gz", hash = "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.14.0-py2.py3-none-any.whl", hash = "sha256:ec3045ae62e1aa2eecfb8e86fa3025c2e3698f77394ef8d2011ce0aedd85b2d4"},
-    {file = "pre_commit-2.14.0.tar.gz", hash = "sha256:2386eeb4cf6633712c7cc9ede83684d53c8cafca6b59f79c738098b51c6d206c"},
+    {file = "pre_commit-2.15.0-py2.py3-none-any.whl", hash = "sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6"},
+    {file = "pre_commit-2.15.0.tar.gz", hash = "sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.20-py3-none-any.whl", hash = "sha256:6076e46efae19b1e0ca1ec003ed37a933dc94b4d20f486235d436e64771dcd5c"},
@@ -3118,8 +3185,8 @@ pyrsistent = [
     {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
 ]
 pytest = [
-    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
-    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-asyncio = [
     {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
@@ -3246,47 +3313,47 @@ readme-renderer = [
     {file = "readme_renderer-28.0.tar.gz", hash = "sha256:6b7e5aa59210a40de72eb79931491eaf46fefca2952b9181268bd7c7c65c260a"},
 ]
 regex = [
-    {file = "regex-2021.8.21-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b0c211c55d4aac4309c3209833c803fada3fc21cdf7b74abedda42a0c9dc3ce"},
-    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d5209c3ba25864b1a57461526ebde31483db295fc6195fdfc4f8355e10f7376"},
-    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c835c30f3af5c63a80917b72115e1defb83de99c73bc727bddd979a3b449e183"},
-    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:615fb5a524cffc91ab4490b69e10ae76c1ccbfa3383ea2fad72e54a85c7d47dd"},
-    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9966337353e436e6ba652814b0a957a517feb492a98b8f9d3b6ba76d22301dcc"},
-    {file = "regex-2021.8.21-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a49f85f0a099a5755d0a2cc6fc337e3cb945ad6390ec892332c691ab0a045882"},
-    {file = "regex-2021.8.21-cp310-cp310-win32.whl", hash = "sha256:f93a9d8804f4cec9da6c26c8cfae2c777028b4fdd9f49de0302e26e00bb86504"},
-    {file = "regex-2021.8.21-cp310-cp310-win_amd64.whl", hash = "sha256:a795829dc522227265d72b25d6ee6f6d41eb2105c15912c230097c8f5bfdbcdc"},
-    {file = "regex-2021.8.21-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bca14dfcfd9aae06d7d8d7e105539bd77d39d06caaae57a1ce945670bae744e0"},
-    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41acdd6d64cd56f857e271009966c2ffcbd07ec9149ca91f71088574eaa4278a"},
-    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96f0c79a70642dfdf7e6a018ebcbea7ea5205e27d8e019cad442d2acfc9af267"},
-    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:45f97ade892ace20252e5ccecdd7515c7df5feeb42c3d2a8b8c55920c3551c30"},
-    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f9974826aeeda32a76648fc677e3125ade379869a84aa964b683984a2dea9f1"},
-    {file = "regex-2021.8.21-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea9753d64cba6f226947c318a923dadaf1e21cd8db02f71652405263daa1f033"},
-    {file = "regex-2021.8.21-cp36-cp36m-win32.whl", hash = "sha256:ef9326c64349e2d718373415814e754183057ebc092261387a2c2f732d9172b2"},
-    {file = "regex-2021.8.21-cp36-cp36m-win_amd64.whl", hash = "sha256:6dbd51c3db300ce9d3171f4106da18fe49e7045232630fe3d4c6e37cb2b39ab9"},
-    {file = "regex-2021.8.21-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a89ca4105f8099de349d139d1090bad387fe2b208b717b288699ca26f179acbe"},
-    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6c2b1d78ceceb6741d703508cd0e9197b34f6bf6864dab30f940f8886e04ade"},
-    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a34ba9e39f8269fd66ab4f7a802794ffea6d6ac500568ec05b327a862c21ce23"},
-    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ecb6e7c45f9cd199c10ec35262b53b2247fb9a408803ed00ee5bb2b54aa626f5"},
-    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:330836ad89ff0be756b58758878409f591d4737b6a8cef26a162e2a4961c3321"},
-    {file = "regex-2021.8.21-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:71a904da8c9c02aee581f4452a5a988c3003207cb8033db426f29e5b2c0b7aea"},
-    {file = "regex-2021.8.21-cp37-cp37m-win32.whl", hash = "sha256:b511c6009d50d5c0dd0bab85ed25bc8ad6b6f5611de3a63a59786207e82824bb"},
-    {file = "regex-2021.8.21-cp37-cp37m-win_amd64.whl", hash = "sha256:93f9f720081d97acee38a411e861d4ce84cbc8ea5319bc1f8e38c972c47af49f"},
-    {file = "regex-2021.8.21-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a195e26df1fbb40ebee75865f9b64ba692a5824ecb91c078cc665b01f7a9a36"},
-    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06ba444bbf7ede3890a912bd4904bb65bf0da8f0d8808b90545481362c978642"},
-    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b8d551f1bd60b3e1c59ff55b9e8d74607a5308f66e2916948cafd13480b44a3"},
-    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ebbceefbffae118ab954d3cd6bf718f5790db66152f95202ebc231d58ad4e2c2"},
-    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ccd721f1d4fc42b541b633d6e339018a08dd0290dc67269df79552843a06ca92"},
-    {file = "regex-2021.8.21-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ae87ab669431f611c56e581679db33b9a467f87d7bf197ac384e71e4956b4456"},
-    {file = "regex-2021.8.21-cp38-cp38-win32.whl", hash = "sha256:38600fd58c2996829480de7d034fb2d3a0307110e44dae80b6b4f9b3d2eea529"},
-    {file = "regex-2021.8.21-cp38-cp38-win_amd64.whl", hash = "sha256:61e734c2bcb3742c3f454dfa930ea60ea08f56fd1a0eb52d8cb189a2f6be9586"},
-    {file = "regex-2021.8.21-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b091dcfee169ad8de21b61eb2c3a75f9f0f859f851f64fdaf9320759a3244239"},
-    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:640ccca4d0a6fcc6590f005ecd7b16c3d8f5d52174e4854f96b16f34c39d6cb7"},
-    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac95101736239260189f426b1e361dc1b704513963357dc474beb0f39f5b7759"},
-    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b79dc2b2e313565416c1e62807c7c25c67a6ff0a0f8d83a318df464555b65948"},
-    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8b623fc429a38a881ab2d9a56ef30e8ea20c72a891c193f5ebbddc016e083ee"},
-    {file = "regex-2021.8.21-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8021dee64899f993f4b5cca323aae65aabc01a546ed44356a0965e29d7893c94"},
-    {file = "regex-2021.8.21-cp39-cp39-win32.whl", hash = "sha256:d6ec4ae13760ceda023b2e5ef1f9bc0b21e4b0830458db143794a117fdbdc044"},
-    {file = "regex-2021.8.21-cp39-cp39-win_amd64.whl", hash = "sha256:03840a07a402576b8e3a6261f17eb88abd653ad4e18ec46ef10c9a63f8c99ebd"},
-    {file = "regex-2021.8.21.tar.gz", hash = "sha256:faf08b0341828f6a29b8f7dd94d5cf8cc7c39bfc3e67b78514c54b494b66915a"},
+    {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308"},
+    {file = "regex-2021.8.28-cp310-cp310-win32.whl", hash = "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed"},
+    {file = "regex-2021.8.28-cp310-cp310-win_amd64.whl", hash = "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8"},
+    {file = "regex-2021.8.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f"},
+    {file = "regex-2021.8.28-cp36-cp36m-win32.whl", hash = "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354"},
+    {file = "regex-2021.8.28-cp36-cp36m-win_amd64.whl", hash = "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645"},
+    {file = "regex-2021.8.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906"},
+    {file = "regex-2021.8.28-cp37-cp37m-win32.whl", hash = "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a"},
+    {file = "regex-2021.8.28-cp37-cp37m-win_amd64.whl", hash = "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc"},
+    {file = "regex-2021.8.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e"},
+    {file = "regex-2021.8.28-cp38-cp38-win32.whl", hash = "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d"},
+    {file = "regex-2021.8.28-cp38-cp38-win_amd64.whl", hash = "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2"},
+    {file = "regex-2021.8.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed"},
+    {file = "regex-2021.8.28-cp39-cp39-win32.whl", hash = "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374"},
+    {file = "regex-2021.8.28-cp39-cp39-win_amd64.whl", hash = "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73"},
+    {file = "regex-2021.8.28.tar.gz", hash = "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
@@ -3372,40 +3439,36 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.3.24-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:87a2725ad7d41cd7376373c15fd8bf674e9c33ca56d0b8036add2d634dba372e"},
-    {file = "SQLAlchemy-1.3.24-cp27-cp27m-win32.whl", hash = "sha256:f597a243b8550a3a0b15122b14e49d8a7e622ba1c9d29776af741f1845478d79"},
-    {file = "SQLAlchemy-1.3.24-cp27-cp27m-win_amd64.whl", hash = "sha256:fc4cddb0b474b12ed7bdce6be1b9edc65352e8ce66bc10ff8cbbfb3d4047dbf4"},
-    {file = "SQLAlchemy-1.3.24-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:f1149d6e5c49d069163e58a3196865e4321bad1803d7886e07d8710de392c548"},
-    {file = "SQLAlchemy-1.3.24-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:14f0eb5db872c231b20c18b1e5806352723a3a89fb4254af3b3e14f22eaaec75"},
-    {file = "SQLAlchemy-1.3.24-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:e98d09f487267f1e8d1179bf3b9d7709b30a916491997137dd24d6ae44d18d79"},
-    {file = "SQLAlchemy-1.3.24-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:fc1f2a5a5963e2e73bac4926bdaf7790c4d7d77e8fc0590817880e22dd9d0b8b"},
-    {file = "SQLAlchemy-1.3.24-cp35-cp35m-win32.whl", hash = "sha256:f3c5c52f7cb8b84bfaaf22d82cb9e6e9a8297f7c2ed14d806a0f5e4d22e83fb7"},
-    {file = "SQLAlchemy-1.3.24-cp35-cp35m-win_amd64.whl", hash = "sha256:0352db1befcbed2f9282e72843f1963860bf0e0472a4fa5cf8ee084318e0e6ab"},
-    {file = "SQLAlchemy-1.3.24-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:2ed6343b625b16bcb63c5b10523fd15ed8934e1ed0f772c534985e9f5e73d894"},
-    {file = "SQLAlchemy-1.3.24-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:34fcec18f6e4b24b4a5f6185205a04f1eab1e56f8f1d028a2a03694ebcc2ddd4"},
-    {file = "SQLAlchemy-1.3.24-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:e47e257ba5934550d7235665eee6c911dc7178419b614ba9e1fbb1ce6325b14f"},
-    {file = "SQLAlchemy-1.3.24-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:816de75418ea0953b5eb7b8a74933ee5a46719491cd2b16f718afc4b291a9658"},
-    {file = "SQLAlchemy-1.3.24-cp36-cp36m-win32.whl", hash = "sha256:26155ea7a243cbf23287f390dba13d7927ffa1586d3208e0e8d615d0c506f996"},
-    {file = "SQLAlchemy-1.3.24-cp36-cp36m-win_amd64.whl", hash = "sha256:f03bd97650d2e42710fbe4cf8a59fae657f191df851fc9fc683ecef10746a375"},
-    {file = "SQLAlchemy-1.3.24-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:a006d05d9aa052657ee3e4dc92544faae5fcbaafc6128217310945610d862d39"},
-    {file = "SQLAlchemy-1.3.24-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1e2f89d2e5e3c7a88e25a3b0e43626dba8db2aa700253023b82e630d12b37109"},
-    {file = "SQLAlchemy-1.3.24-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0d5d862b1cfbec5028ce1ecac06a3b42bc7703eb80e4b53fceb2738724311443"},
-    {file = "SQLAlchemy-1.3.24-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:0172423a27fbcae3751ef016663b72e1a516777de324a76e30efa170dbd3dd2d"},
-    {file = "SQLAlchemy-1.3.24-cp37-cp37m-win32.whl", hash = "sha256:d37843fb8df90376e9e91336724d78a32b988d3d20ab6656da4eb8ee3a45b63c"},
-    {file = "SQLAlchemy-1.3.24-cp37-cp37m-win_amd64.whl", hash = "sha256:c10ff6112d119f82b1618b6dc28126798481b9355d8748b64b9b55051eb4f01b"},
-    {file = "SQLAlchemy-1.3.24-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:861e459b0e97673af6cc5e7f597035c2e3acdfb2608132665406cded25ba64c7"},
-    {file = "SQLAlchemy-1.3.24-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5de2464c254380d8a6c20a2746614d5a436260be1507491442cf1088e59430d2"},
-    {file = "SQLAlchemy-1.3.24-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d375d8ccd3cebae8d90270f7aa8532fe05908f79e78ae489068f3b4eee5994e8"},
-    {file = "SQLAlchemy-1.3.24-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:014ea143572fee1c18322b7908140ad23b3994036ef4c0d630110faf942652f8"},
-    {file = "SQLAlchemy-1.3.24-cp38-cp38-win32.whl", hash = "sha256:6607ae6cd3a07f8a4c3198ffbf256c261661965742e2b5265a77cd5c679c9bba"},
-    {file = "SQLAlchemy-1.3.24-cp38-cp38-win_amd64.whl", hash = "sha256:fcb251305fa24a490b6a9ee2180e5f8252915fb778d3dafc70f9cc3f863827b9"},
-    {file = "SQLAlchemy-1.3.24-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:01aa5f803db724447c1d423ed583e42bf5264c597fd55e4add4301f163b0be48"},
-    {file = "SQLAlchemy-1.3.24-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4d0e3515ef98aa4f0dc289ff2eebb0ece6260bbf37c2ea2022aad63797eacf60"},
-    {file = "SQLAlchemy-1.3.24-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:bce28277f308db43a6b4965734366f533b3ff009571ec7ffa583cb77539b84d6"},
-    {file = "SQLAlchemy-1.3.24-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8110e6c414d3efc574543109ee618fe2c1f96fa31833a1ff36cc34e968c4f233"},
-    {file = "SQLAlchemy-1.3.24-cp39-cp39-win32.whl", hash = "sha256:ee5f5188edb20a29c1cc4a039b074fdc5575337c9a68f3063449ab47757bb064"},
-    {file = "SQLAlchemy-1.3.24-cp39-cp39-win_amd64.whl", hash = "sha256:09083c2487ca3c0865dc588e07aeaa25416da3d95f7482c07e92f47e080aa17b"},
-    {file = "SQLAlchemy-1.3.24.tar.gz", hash = "sha256:ebbb777cbf9312359b897bf81ba00dae0f5cb69fba2a18265dcc18a6f5ef7519"},
+    {file = "SQLAlchemy-1.4.23-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:25e9b2e5ca088879ce3740d9ccd4d58cb9061d49566a0b5e12166f403d6f4da0"},
+    {file = "SQLAlchemy-1.4.23-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d9667260125688c71ccf9af321c37e9fb71c2693575af8210f763bfbbee847c7"},
+    {file = "SQLAlchemy-1.4.23-cp27-cp27m-win32.whl", hash = "sha256:cec1a4c6ddf5f82191301a25504f0e675eccd86635f0d5e4c69e0661691931c5"},
+    {file = "SQLAlchemy-1.4.23-cp27-cp27m-win_amd64.whl", hash = "sha256:ae07895b55c7d58a7dd47438f437ac219c0f09d24c2e7d69fdebc1ea75350f00"},
+    {file = "SQLAlchemy-1.4.23-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:967307ea52985985224a79342527c36ec2d1daa257a39748dd90e001a4be4d90"},
+    {file = "SQLAlchemy-1.4.23-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:be185b3daf651c6c0639987a916bf41e97b60e68f860f27c9cb6574385f5cbb4"},
+    {file = "SQLAlchemy-1.4.23-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a0d3b3d51c83a66f5b72c57e1aad061406e4c390bd42cf1fda94effe82fac81"},
+    {file = "SQLAlchemy-1.4.23-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a8395c4db3e1450eef2b68069abf500cc48af4b442a0d98b5d3c9535fe40cde8"},
+    {file = "SQLAlchemy-1.4.23-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b128a78581faea7a5ee626ad4471353eee051e4e94616dfeff4742b6e5ba262"},
+    {file = "SQLAlchemy-1.4.23-cp36-cp36m-win32.whl", hash = "sha256:43fc207be06e50158e4dae4cc4f27ce80afbdbfa7c490b3b22feb64f6d9775a0"},
+    {file = "SQLAlchemy-1.4.23-cp36-cp36m-win_amd64.whl", hash = "sha256:e9d4f4552aa5e0d1417fc64a2ce1cdf56a30bab346ba6b0dd5e838eb56db4d29"},
+    {file = "SQLAlchemy-1.4.23-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:512f52a8872e8d63d898e4e158eda17e2ee40b8d2496b3b409422e71016db0bd"},
+    {file = "SQLAlchemy-1.4.23-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:355024cf061ed04271900414eb4a22671520241d2216ddb691bdd8a992172389"},
+    {file = "SQLAlchemy-1.4.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:82c03325111eab88d64e0ff48b6fe15c75d23787429fa1d84c0995872e702787"},
+    {file = "SQLAlchemy-1.4.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0aa312f9906ecebe133d7f44168c3cae4c76f27a25192fa7682f3fad505543c9"},
+    {file = "SQLAlchemy-1.4.23-cp37-cp37m-win32.whl", hash = "sha256:059c5f41e8630f51741a234e6ba2a034228c11b3b54a15478e61d8b55fa8bd9d"},
+    {file = "SQLAlchemy-1.4.23-cp37-cp37m-win_amd64.whl", hash = "sha256:cd68c5f9d13ffc8f4d6802cceee786678c5b1c668c97bc07b9f4a60883f36cd1"},
+    {file = "SQLAlchemy-1.4.23-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:6a8dbf3d46e889d864a57ee880c4ad3a928db5aa95e3d359cbe0da2f122e50c4"},
+    {file = "SQLAlchemy-1.4.23-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c15191f2430a30082f540ec6f331214746fc974cfdf136d7a1471d1c61d68ff"},
+    {file = "SQLAlchemy-1.4.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cd0e85dd2067159848c7672acd517f0c38b7b98867a347411ea01b432003f8d9"},
+    {file = "SQLAlchemy-1.4.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370f4688ce47f0dc1e677a020a4d46252a31a2818fd67f5c256417faefc938af"},
+    {file = "SQLAlchemy-1.4.23-cp38-cp38-win32.whl", hash = "sha256:bd41f8063a9cd11b76d6d7d6af8139ab3c087f5dbbe5a50c02cb8ece7da34d67"},
+    {file = "SQLAlchemy-1.4.23-cp38-cp38-win_amd64.whl", hash = "sha256:2bca9a6e30ee425cc321d988a152a5fe1be519648e7541ac45c36cd4f569421f"},
+    {file = "SQLAlchemy-1.4.23-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:4803a481d4c14ce6ad53dc35458c57821863e9a079695c27603d38355e61fb7f"},
+    {file = "SQLAlchemy-1.4.23-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07b9099a95dd2b2620498544300eda590741ac54915c6b20809b6de7e3c58090"},
+    {file = "SQLAlchemy-1.4.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:37f2bd1b8e32c5999280f846701712347fc0ee7370e016ede2283c71712e127a"},
+    {file = "SQLAlchemy-1.4.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:448612570aa1437a5d1b94ada161805778fe80aba5b9a08a403e8ae4e071ded6"},
+    {file = "SQLAlchemy-1.4.23-cp39-cp39-win32.whl", hash = "sha256:e0ce4a2e48fe0a9ea3a5160411a4c5135da5255ed9ac9c15f15f2bcf58c34194"},
+    {file = "SQLAlchemy-1.4.23-cp39-cp39-win_amd64.whl", hash = "sha256:0aa746d1173587743960ff17b89b540e313aacfe6c1e9c81aa48393182c36d4f"},
+    {file = "SQLAlchemy-1.4.23.tar.gz", hash = "sha256:76ff246881f528089bf19385131b966197bb494653990396d2ce138e2a447583"},
 ]
 sshpubkeys = [
     {file = "sshpubkeys-3.3.1-py2.py3-none-any.whl", hash = "sha256:946f76b8fe86704b0e7c56a00d80294e39bc2305999844f079a217885060b1ac"},
@@ -3432,8 +3495,8 @@ tqdm = [
     {file = "tqdm-4.62.2.tar.gz", hash = "sha256:a4d6d112e507ef98513ac119ead1159d286deab17dffedd96921412c2d236ff5"},
 ]
 traitlets = [
-    {file = "traitlets-5.0.5-py3-none-any.whl", hash = "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"},
-    {file = "traitlets-5.0.5.tar.gz", hash = "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396"},
+    {file = "traitlets-5.1.0-py3-none-any.whl", hash = "sha256:03f172516916220b58c9f19d7f854734136dd9528103d04e9bf139a92c9f54c4"},
+    {file = "traitlets-5.1.0.tar.gz", hash = "sha256:bd382d7ea181fbbcce157c133db9a829ce06edffe097bcf3ab945b435452b46d"},
 ]
 twine = [
     {file = "twine-3.4.2-py3-none-any.whl", hash = "sha256:087328e9bb405e7ce18527a2dca4042a84c7918658f951110b38bc135acab218"},
@@ -3472,13 +3535,13 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 unidecode = [
-    {file = "Unidecode-1.2.0-py2.py3-none-any.whl", hash = "sha256:12435ef2fc4cdfd9cf1035a1db7e98b6b047fe591892e81f34e94959591fad00"},
-    {file = "Unidecode-1.2.0.tar.gz", hash = "sha256:8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d"},
+    {file = "Unidecode-1.3.0-py2.py3-none-any.whl", hash = "sha256:d01b0a22f7d90dea483da658782884de5162f40359fcaf79630738db93045c84"},
+    {file = "Unidecode-1.3.0.tar.gz", hash = "sha256:9f8235681cc520912fe02e7dd73d455c2f0471f39d36485bc278b97b3e2f2390"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -665,7 +665,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "identify"
-version = "2.2.13"
+version = "2.2.14"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -953,6 +953,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mirakuru"
+version = "2.4.1"
+description = "Process executor (not only) for tests."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+psutil = {version = ">=4.0.0", markers = "sys_platform != \"cygwin\""}
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "python-daemon"]
+
+[[package]]
 name = "mistune"
 version = "0.8.4"
 description = "The fastest markdown parser in pure Python"
@@ -1202,6 +1216,17 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "port-for"
+version = "0.6.1"
+description = "Utility that helps with local TCP ports management. It can find an unused TCP localhost port and remember the association."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "mock"]
+
+[[package]]
 name = "pre-commit"
 version = "2.15.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -1228,6 +1253,17 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+name = "psutil"
+version = "5.8.0"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
 name = "ptyprocess"
@@ -1320,6 +1356,21 @@ description = "C parser in Python"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pydantic"
+version = "1.8.2"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pyflakes"
@@ -1564,6 +1615,23 @@ importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""
 pytest = "*"
 
 [[package]]
+name = "pytest-redis"
+version = "2.1.1"
+description = "Redis fixtures and fixture factories for Pytest."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mirakuru = "*"
+port-for = "*"
+pytest = "*"
+redis = "*"
+
+[package.extras]
+tests = ["pytest-cov", "pytest-xdist", "mock"]
+
+[[package]]
 name = "pytest-vcr"
 version = "1.0.2"
 description = "Plugin for managing VCR.py cassettes"
@@ -1683,6 +1751,17 @@ six = "*"
 
 [package.extras]
 md = ["cmarkgfm (>=0.2.0)"]
+
+[[package]]
+name = "redis"
+version = "3.5.3"
+description = "Python client for Redis key-value store"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+hiredis = ["hiredis (>=0.1.3)"]
 
 [[package]]
 name = "regex"
@@ -2293,7 +2372,7 @@ docs = ["Sphinx", "sphinx-autoapi", "sphinx-autodoc-typehints", "sphinx-rtd-them
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f149074fe201e9fc00e909ba86e4daf6d17456550d4247c88b209f1edfbbc918"
+content-hash = "9ffa1caf3bf06785b29124a8cb925d4bf12c37e94031973783ecffed7ad87149"
 
 [metadata.files]
 aio-botocore = [
@@ -2805,8 +2884,8 @@ hiredis = [
     {file = "hiredis-2.0.0.tar.gz", hash = "sha256:81d6d8e39695f2c37954d1011c0480ef7cf444d4e3ae24bc5e89ee5de360139a"},
 ]
 identify = [
-    {file = "identify-2.2.13-py2.py3-none-any.whl", hash = "sha256:7199679b5be13a6b40e6e19ea473e789b11b4e3b60986499b1f589ffb03c217c"},
-    {file = "identify-2.2.13.tar.gz", hash = "sha256:7bc6e829392bd017236531963d2d937d66fc27cadc643ac0aba2ce9f26157c79"},
+    {file = "identify-2.2.14-py2.py3-none-any.whl", hash = "sha256:113a76a6ba614d2a3dd408b3504446bcfac0370da5995aa6a17fd7c6dffde02d"},
+    {file = "identify-2.2.14.tar.gz", hash = "sha256:32f465f3c48083f345ad29a9df8419a4ce0674bf4a8c3245191d65c83634bdbf"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -2967,6 +3046,10 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+mirakuru = [
+    {file = "mirakuru-2.4.1-py3-none-any.whl", hash = "sha256:097324abe7479b3e6a8b745d0e3980664c8f6d3aec06cdeff8fc38cb2c9abc93"},
+    {file = "mirakuru-2.4.1.tar.gz", hash = "sha256:7025d121d2f04e957bd6ae3239531d60ebba787839c89d6052479beb58b0cd0b"},
+]
 mistune = [
     {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
@@ -3095,6 +3178,10 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+port-for = [
+    {file = "port-for-0.6.1.tar.gz", hash = "sha256:aa5dedbc138c614d4cc9d1ff2a56a348f6d98b21a35497987fc60c0b2959f6e4"},
+    {file = "port_for-0.6.1-py3-none-any.whl", hash = "sha256:93cbb9a01c2f64914868f81b49ae618c53fd32ef3231fd2144d3f2b62b58821f"},
+]
 pre-commit = [
     {file = "pre_commit-2.15.0-py2.py3-none-any.whl", hash = "sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6"},
     {file = "pre_commit-2.15.0.tar.gz", hash = "sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7"},
@@ -3102,6 +3189,36 @@ pre-commit = [
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.20-py3-none-any.whl", hash = "sha256:6076e46efae19b1e0ca1ec003ed37a933dc94b4d20f486235d436e64771dcd5c"},
     {file = "prompt_toolkit-3.0.20.tar.gz", hash = "sha256:eb71d5a6b72ce6db177af4a7d4d7085b99756bf656d98ffcc4fecd36850eea6c"},
+]
+psutil = [
+    {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
+    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c"},
+    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df"},
+    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131"},
+    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60"},
+    {file = "psutil-5.8.0-cp27-none-win32.whl", hash = "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876"},
+    {file = "psutil-5.8.0-cp27-none-win_amd64.whl", hash = "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65"},
+    {file = "psutil-5.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8"},
+    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6"},
+    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac"},
+    {file = "psutil-5.8.0-cp36-cp36m-win32.whl", hash = "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2"},
+    {file = "psutil-5.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d"},
+    {file = "psutil-5.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935"},
+    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d"},
+    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023"},
+    {file = "psutil-5.8.0-cp37-cp37m-win32.whl", hash = "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394"},
+    {file = "psutil-5.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"},
+    {file = "psutil-5.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef"},
+    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28"},
+    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b"},
+    {file = "psutil-5.8.0-cp38-cp38-win32.whl", hash = "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d"},
+    {file = "psutil-5.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d"},
+    {file = "psutil-5.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7"},
+    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4"},
+    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b"},
+    {file = "psutil-5.8.0-cp39-cp39-win32.whl", hash = "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0"},
+    {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
+    {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -3140,6 +3257,30 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pydantic = [
+    {file = "pydantic-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a7c6002203fe2c5a1b5cbb141bb85060cbff88c2d78eccbc72d97eb7022c43e4"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:589eb6cd6361e8ac341db97602eb7f354551482368a37f4fd086c0733548308e"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:10e5622224245941efc193ad1d159887872776df7a8fd592ed746aa25d071840"},
+    {file = "pydantic-1.8.2-cp36-cp36m-win_amd64.whl", hash = "sha256:99a9fc39470010c45c161a1dc584997f1feb13f689ecf645f59bb4ba623e586b"},
+    {file = "pydantic-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a83db7205f60c6a86f2c44a61791d993dff4b73135df1973ecd9eed5ea0bda20"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:41b542c0b3c42dc17da70554bc6f38cbc30d7066d2c2815a94499b5684582ecb"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:ea5cb40a3b23b3265f6325727ddfc45141b08ed665458be8c6285e7b85bd73a1"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:18b5ea242dd3e62dbf89b2b0ec9ba6c7b5abaf6af85b95a97b00279f65845a23"},
+    {file = "pydantic-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:234a6c19f1c14e25e362cb05c68afb7f183eb931dd3cd4605eafff055ebbf287"},
+    {file = "pydantic-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:021ea0e4133e8c824775a0cfe098677acf6fa5a3cbf9206a376eed3fc09302cd"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e710876437bc07bd414ff453ac8ec63d219e7690128d925c6e82889d674bb505"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:ac8eed4ca3bd3aadc58a13c2aa93cd8a884bcf21cb019f8cfecaae3b6ce3746e"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:4a03cbbe743e9c7247ceae6f0d8898f7a64bb65800a45cbdc52d65e370570820"},
+    {file = "pydantic-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:8621559dcf5afacf0069ed194278f35c255dc1a1385c28b32dd6c110fd6531b3"},
+    {file = "pydantic-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8b223557f9510cf0bfd8b01316bf6dd281cf41826607eada99662f5e4963f316"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:244ad78eeb388a43b0c927e74d3af78008e944074b7d0f4f696ddd5b2af43c62"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:05ef5246a7ffd2ce12a619cbb29f3307b7c4509307b1b49f456657b43529dc6f"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:54cd5121383f4a461ff7644c7ca20c0419d58052db70d8791eacbbe31528916b"},
+    {file = "pydantic-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:4be75bebf676a5f0f87937c6ddb061fa39cbea067240d98e298508c1bda6f3f3"},
+    {file = "pydantic-1.8.2-py3-none-any.whl", hash = "sha256:fec866a0b59f372b7e776f2d7308511784dace622e0992a0b59ea3ccee0ae833"},
+    {file = "pydantic-1.8.2.tar.gz", hash = "sha256:26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b"},
 ]
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
@@ -3236,6 +3377,10 @@ pytest-randomly = [
     {file = "pytest-randomly-3.10.1.tar.gz", hash = "sha256:d4ef5dbf27e542e6a4e4cec7a20ef3f1b906bce21fa340ca5657b5326ef23a64"},
     {file = "pytest_randomly-3.10.1-py3-none-any.whl", hash = "sha256:d28d490e3a743bdd64c5bc87c5fc182eac966ba6432c6bb6b224e32e76527e9e"},
 ]
+pytest-redis = [
+    {file = "pytest-redis-2.1.1.tar.gz", hash = "sha256:d8126e1929bdacb7f5db913327662e9841cbd78512c620c0c66100f226e55074"},
+    {file = "pytest_redis-2.1.1-py3-none-any.whl", hash = "sha256:54fe89691a69f8dedea2cc6b63e94d6f2c338490377d5a0c14bc0cfbf6a24a3a"},
+]
 pytest-vcr = [
     {file = "pytest-vcr-1.0.2.tar.gz", hash = "sha256:23ee51b75abbcc43d926272773aae4f39f93aceb75ed56852d0bf618f92e1896"},
     {file = "pytest_vcr-1.0.2-py2.py3-none-any.whl", hash = "sha256:2f316e0539399bea0296e8b8401145c62b6f85e9066af7e57b6151481b0d6d9c"},
@@ -3311,6 +3456,10 @@ pyyaml = [
 readme-renderer = [
     {file = "readme_renderer-28.0-py2.py3-none-any.whl", hash = "sha256:267854ac3b1530633c2394ead828afcd060fc273217c42ac36b6be9c42cd9a9d"},
     {file = "readme_renderer-28.0.tar.gz", hash = "sha256:6b7e5aa59210a40de72eb79931491eaf46fefca2952b9181268bd7c7c65c260a"},
+]
+redis = [
+    {file = "redis-3.5.3-py2.py3-none-any.whl", hash = "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"},
+    {file = "redis-3.5.3.tar.gz", hash = "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2"},
 ]
 regex = [
     {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ moto = {version = "~1.3.16", extras = ["server"]}
 # py-dev-deps is used as a common denominator for many
 # development dependencies
 py-dev-deps = "^0.2"
+pytest-redis = "^2.1.1"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ aio-botocore = {version = "~1.3.0"}
 boto3 = "^1.17.100"
 botocore = "^1.20.100"
 
+pydantic = "^1.8.2"
 PyYAML = "^5.2"
 requests = "^2.23.0"
 tinydb = "^3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ tinydb = "^3.15"
 
 awscli = {version = "^1.18", optional = true}
 
-aioredis = {version = "^1.3", optional = true}
+aioredis = {extras = ["hiredis"], version = "^2.0", optional = true}
 databases = {extras = ["postgresql", "mysql", "sqlite"], version = "*", optional = true}
 
 # Optional docs pages for readthedocs builds
@@ -69,6 +69,10 @@ all = [
     "aioredis",
     "databases",
 ]
+
+aioredis = ["aioredis"]
+
+databases = ["databases"]
 
 # it's generally advised that awscli is installed separately
 # into a system installation rather than a venv installation,

--- a/tests/aws_batch_db/conftest.py
+++ b/tests/aws_batch_db/conftest.py
@@ -1,0 +1,61 @@
+import pytest
+
+from aio_aws.aio_aws_batch import AWSBatchJob
+
+
+@pytest.fixture
+def aws_batch_job() -> AWSBatchJob:
+    job_data = {
+        "job_id": "1aac2eab-897a-4b89-9eb3-08986fbb7144",
+        "job_name": "sleep-1-job",
+        "job_queue": "arn:aws:batch:us-west-2:123456789012:job-queue/moto_test_job_queue",
+        "job_submission": {
+            "ResponseMetadata": {
+                "HTTPHeaders": {
+                    "content-length": "75",
+                    "content-type": "text/html; " "charset=utf-8",
+                    "date": "Mon, 23 Mar " "2020 " "15:29:33 GMT",
+                    "server": "amazon.com",
+                },
+                "HTTPStatusCode": 200,
+                "RetryAttempts": 0,
+            },
+            "jobId": "1aac2eab-897a-4b89-9eb3-08986fbb7144",
+            "jobName": "sleep-1-job",
+        },
+        "job_tries": ["1aac2eab-897a-4b89-9eb3-08986fbb7144"],
+        "max_tries": 4,
+        "num_tries": 1,
+        "status": "SUCCEEDED",
+        "command": ["/bin/sh", "-c", "echo Hello && sleep 0.2 && echo Bye"],
+        "container_overrides": {
+            "command": ["/bin/sh", "-c", "echo Hello && sleep 0.2 && echo Bye"]
+        },
+        "depends_on": [],
+        "job_definition": "arn:aws:batch:us-west-2:123456789012:job-definition/moto_test_job_definition:1",
+        "job_description": {
+            "container": {
+                "command": [
+                    '/bin/sh -c "for a in `seq 1 '
+                    "10`; do echo Hello World; "
+                    'sleep 1; done"'
+                ],
+                "logStreamName": "moto_test_job_definition/default/1aac2eab-897a-4b89-9eb3-08986fbb7144",
+                "privileged": False,
+                "readonlyRootFilesystem": False,
+                "ulimits": [],
+                "vcpus": 1,
+                "volumes": [],
+            },
+            "dependsOn": [],
+            "jobDefinition": "arn:aws:batch:us-west-2:123456789012:job-definition/moto_test_job_definition:1",
+            "jobId": "1aac2eab-897a-4b89-9eb3-08986fbb7144",
+            "jobName": "sleep-1-job",
+            "jobQueue": "arn:aws:batch:us-west-2:123456789012:job-queue/moto_test_job_queue",
+            "createdAt": 1584977374,  # https://github.com/spulec/moto/issues/2829
+            "startedAt": 1584977376,
+            "status": "SUCCEEDED",
+            "stoppedAt": 1584977386,
+        },
+    }
+    return AWSBatchJob(**job_data)

--- a/tests/aws_batch_db/test_aio_aws_batch_db.py
+++ b/tests/aws_batch_db/test_aio_aws_batch_db.py
@@ -1,0 +1,261 @@
+# Copyright 2020 Darren Weber
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test Aio AWS Batch DB
+"""
+from typing import Dict
+from typing import List
+from typing import Set
+
+import pytest
+
+from aio_aws.aio_aws_batch import AWSBatchJob
+from aio_aws.aio_aws_batch_db import AioAWSBatchDB
+
+
+@pytest.fixture
+def redis_url(redisdb) -> str:
+    redis_client = redisdb.client()
+    yield f"unix://{redis_client.connection.path}"
+
+
+@pytest.fixture
+@pytest.mark.asyncio
+async def aioredis_jobs_db(redis_url) -> AioAWSBatchDB:
+    batch_jobs_db = AioAWSBatchDB(redis_url=redis_url)
+    key_count = 0
+    async for key in batch_jobs_db.jobs_db.scan_iter():
+        key_count += 1
+    async for key in batch_jobs_db.logs_db.scan_iter():
+        key_count += 1
+    assert key_count == 0
+    yield batch_jobs_db
+
+
+@pytest.mark.asyncio
+async def test_aio_aws_batch_db_init(redis_url):
+    batch_db = AioAWSBatchDB(redis_url=redis_url)
+    assert await batch_db.db_alive is True
+    db_info = await batch_db.db_info
+    assert db_info["jobs"]["redis_version"]
+    assert db_info["logs"]["redis_version"]
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_save(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    assert job.job_id
+    assert job.job_name
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    db_job = await aioredis_jobs_db.find_by_job_id(job.job_id)
+    assert db_job
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_find_by_job_id(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    job_dict = await aioredis_jobs_db.find_by_job_id(job.job_id)
+    assert isinstance(job_dict, dict)
+    assert job_dict["job_id"] == job.job_id
+    assert job_dict["job_name"] == job.job_name
+    assert job_dict["status"] == job.status
+    # test all the fields, since it behaves like a dict
+    assert job.db_data == job_dict
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_remove_by_job_id(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    job_dict = await aioredis_jobs_db.remove_by_job_id(job.job_id)
+    assert isinstance(job_dict, Dict)
+    assert job.db_data == job_dict
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_find_by_job_name(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    job_dicts = await aioredis_jobs_db.find_by_job_name(job.job_name)
+    assert isinstance(job_dicts, List)
+    assert len(job_dicts) == 1
+    job_dict = job_dicts[0]
+    assert isinstance(job_dict, Dict)
+    assert job.db_data == job_dict
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_remove_by_job_name(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    job_ids = await aioredis_jobs_db.remove_by_job_name(job.job_name)
+    assert isinstance(job_ids, Set)
+    assert len(job_ids) == 1
+    for job_id in job_ids:
+        assert isinstance(job_id, str)
+        assert job_id == job.job_id
+    job_id = await aioredis_jobs_db.find_by_job_id(job.job_id)
+    assert job_id is None
+    job_id = await aioredis_jobs_db.remove_by_job_id(job.job_id)
+    assert job_id is None
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_find_jobs_to_run(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job.status = "SUBMITTED"  # this job can be 'recovered'
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    jobs = await aioredis_jobs_db.find_jobs_to_run()
+    assert isinstance(jobs, List)
+    assert len(jobs) == 1
+    assert isinstance(jobs[0], AWSBatchJob)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_find_jobs_to_run_empty(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    assert job.status == "SUCCEEDED"
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    jobs = await aioredis_jobs_db.find_jobs_to_run()
+    assert isinstance(jobs, List)
+    assert len(jobs) == 0  # successful jobs are done
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_filter_jobs_to_run(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job.status = "SUBMITTED"  # this job can be 'recovered'
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert isinstance(jobs, List)
+    assert len(jobs) == 1
+    assert isinstance(jobs[0], AWSBatchJob)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_jobs_to_run_empty(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    assert job.status == "SUCCEEDED"
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert isinstance(jobs, List)
+    assert len(jobs) == 0  # successful jobs are done
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_saved_filter_jobs_to_run(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job.status = "SUBMITTED"  # this job can be 'recovered'
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert isinstance(jobs, List)
+    assert len(jobs) == 1
+    assert isinstance(jobs[0], AWSBatchJob)
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_saved_filter_jobs_to_run_empty(
+    aioredis_jobs_db, aws_batch_job
+):
+    job = aws_batch_job
+    assert job.status == "SUCCEEDED"
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert isinstance(jobs, List)
+    assert len(jobs) == 0  # successful jobs are done
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_saved_filter_jobs_to_run_for_recovery(
+    aioredis_jobs_db, aws_batch_job
+):
+    job = aws_batch_job
+    assert job.status == "SUCCEEDED"
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert len(jobs) == 0  # successful jobs are done
+    # Assume the job is recreated and needs to be recovered from the db
+    job.reset()
+    assert job.job_id is None
+    assert job.job_name  # used to recover the job from the db
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert isinstance(jobs, List)
+    assert len(jobs) == 0  # the job.job_name is used to recover the job
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_find_latest_job_name(aioredis_jobs_db, aws_batch_job):
+    job = aws_batch_job
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+
+    # Fake another submission of the same job-name
+    new_job_dict = job.db_data
+    new_job_dict["job_id"] = job.job_id.replace("08986fbb7144", "08986fbb7145")
+    new_job = AWSBatchJob(**new_job_dict)
+    new_job.job_submission["jobId"] = new_job.job_id
+    new_job.job_description["status"] = "SUCCEEDED"
+    new_job.status = job.job_description["status"]
+    new_job.job_description["createdAt"] += 5
+    new_job.job_description["startedAt"] += 5
+    new_job.job_description["stoppedAt"] += 5
+    job_id = await aioredis_jobs_db.save_job(new_job)
+    assert job_id == new_job.job_id
+    job_dicts = await aioredis_jobs_db.find_by_job_name(job.job_name)
+    assert len(job_dicts) == 2
+    assert sorted([j["job_id"] for j in job_dicts]) == sorted(
+        [job.job_id, new_job.job_id]
+    )
+    job_found = await aioredis_jobs_db.find_latest_job_name(job.job_name)
+    assert job_found.job_id == new_job.job_id
+
+
+@pytest.mark.asyncio
+async def test_batch_job_db_saved_filter_jobs_to_run_with_duplicate(
+    aioredis_jobs_db, aws_batch_job
+):
+    job = aws_batch_job
+    # Fake a job failure
+    job.job_description["status"] = "FAILED"
+    job.status = job.job_description["status"]
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert len(jobs) == 1  # failed jobs could be run again (if reset)
+
+    # Fake another submission of the same job-name
+    fake_job_id = job.job_id.replace("08986fbb7144", "08986fbb7145")
+    job.job_id = fake_job_id
+    job.job_submission["jobId"] = fake_job_id
+    job.job_description["status"] = "SUCCEEDED"
+    job.status = job.job_description["status"]
+    job.job_description["createdAt"] += 5
+    job.job_description["startedAt"] += 5
+    job.job_description["stoppedAt"] += 5
+    job_id = await aioredis_jobs_db.save_job(job)
+    assert job_id == job.job_id
+
+    jobs = await aioredis_jobs_db.jobs_to_run([job])
+    assert len(jobs) == 0  # successful jobs are done

--- a/tests/aws_batch_db/test_redis_db.py
+++ b/tests/aws_batch_db/test_redis_db.py
@@ -1,0 +1,11 @@
+def test_redis(redisdb):
+    """Check that it's actually working on aws_batch_db database."""
+    redisdb.set("key1", "value1")
+    redisdb.set("key2", "value2")
+    assert redisdb.get("key1") == b"value1"
+    assert redisdb.get("key2") == b"value2"
+
+
+def test_redis_client(redisdb):
+    redis_client = redisdb.client()
+    assert "sock" in redis_client.connection.path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ AioAWS test fixtures
 
 import pytest
 
-from aio_aws.aio_aws_batch import AWSBatchDB
+from aio_aws.aws_batch_db import AWSBatchDB
 
 pytest_plugins = [
     "tests.fixtures.aws_fixtures",

--- a/tests/fixtures/aiomoto_fixtures.py
+++ b/tests/fixtures/aiomoto_fixtures.py
@@ -33,8 +33,8 @@ from typing import Optional
 import aiobotocore.client
 import aiobotocore.config
 import pytest
-
 from moto.core.models import BotocoreStubber
+
 from tests.fixtures.aiomoto_services import MotoService
 
 AWS_REGION = "us-west-2"

--- a/tests/test_aio_aws_batch.py
+++ b/tests/test_aio_aws_batch.py
@@ -42,7 +42,7 @@ from aio_aws.aio_aws_batch import aio_batch_job_terminate
 from aio_aws.aio_aws_batch import aio_batch_job_waiter
 from aio_aws.aio_aws_batch import aio_batch_run_jobs
 from aio_aws.aio_aws_batch import AWSBatchConfig
-from aio_aws.aio_aws_batch import AWSBatchJob
+from aio_aws.aws_batch_models import AWSBatchJob
 from aio_aws.utils import response_success
 from tests.fixtures.aiomoto_fixtures import aio_batch_infrastructure
 from tests.fixtures.aiomoto_fixtures import AioAwsBatchClients

--- a/tests/test_s3_aio.py
+++ b/tests/test_s3_aio.py
@@ -1,14 +1,10 @@
-import asyncio
 import tempfile
 from datetime import datetime
-from functools import partial
 from pathlib import Path
 from typing import Dict
 
 import pytest
 
-from aio_aws.aio_aws_config import aio_aws_client
-from aio_aws.aio_aws_config import aio_aws_default_config
 from aio_aws.s3_aio import geojson_s3_dump
 from aio_aws.s3_aio import geojson_s3_load
 from aio_aws.s3_aio import geojsons_dump

--- a/tests/test_uuid_utils.py
+++ b/tests/test_uuid_utils.py
@@ -1,0 +1,26 @@
+from aio_aws.uuid_utils import get_hex_uuid
+from aio_aws.uuid_utils import get_hex_uuids
+from aio_aws.uuid_utils import get_uuid
+from aio_aws.uuid_utils import get_uuids
+from aio_aws.uuid_utils import valid_hex_uuid4
+from aio_aws.uuid_utils import valid_uuid4
+
+
+def test_get_uuid():
+    uuid = get_uuid()
+    assert valid_uuid4(uuid)
+
+
+def test_get_hex_uuid():
+    hex_uuid = get_hex_uuid()
+    assert valid_hex_uuid4(hex_uuid)
+
+
+def test_get_uuids():
+    uuids = get_uuids(10)
+    assert all([valid_uuid4(uuid) for uuid in uuids])
+
+
+def test_get_hex_uuids():
+    hex_uuids = get_hex_uuids(10)
+    assert all([valid_hex_uuid4(uuid) for uuid in hex_uuids])


### PR DESCRIPTION
This refactor has breaking changes to AWS Batch functions, due to refactoring components into new modules and other refactoring of functions into instance methods.  The introduction of an aioredis implementation for batch-db functions introduces asyncio equivalents of methods already implemented on tinydb.  It's not obvious that an ABC could capture an API for both sync and async methods, but later work on that might try to define something that could allow either db implementation to be swapped out as required.  Further work might require aioredis as a hard dependency and make that implementation the default.
