### PR TITLE
Add json and pydantic support for S3URI

### DIFF
--- a/tests/test_s3_aio.py
+++ b/tests/test_s3_aio.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -50,7 +50,7 @@ async def test_s3_aio_file_info(
     assert s3_info.s3_uri == S3URI(s3_uri)
     assert s3_info.s3_size == len(s3_text)
     assert isinstance(s3_info.last_modified, datetime)
-    s3_dict = s3_info.dict
+    s3_dict = s3_info.dict()
     assert isinstance(s3_dict, Dict)
     assert s3_dict["s3_uri"] == s3_uri
     assert s3_dict["s3_size"] == len(s3_text)
@@ -58,6 +58,9 @@ async def test_s3_aio_file_info(
     assert isinstance(s3_dict["last_modified"], str)
     last_modified = datetime.fromisoformat(s3_dict["last_modified"])
     assert isinstance(last_modified, datetime)
+    # test the JSON representation
+    s3_json = s3_info.json()
+    assert s3_json == json.dumps(s3_dict)
 
 
 @pytest.mark.asyncio

--- a/tests/test_s3_io.py
+++ b/tests/test_s3_io.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -48,7 +48,7 @@ def test_s3_file_info(aws_s3_client, s3_uri_object, s3_object_text, mocker):
     spy_resource = mocker.spy(boto3, "resource")
     s3_info = s3_file_info(s3_uri_object.s3_uri)
     assert isinstance(s3_info, S3Info)
-    s3_dict = s3_info.dict
+    s3_dict = s3_info.dict()
     assert isinstance(s3_dict, Dict)
     assert s3_dict["s3_uri"] == s3_uri_object.s3_uri
     assert s3_dict["s3_size"] == len(s3_object_text)
@@ -56,6 +56,9 @@ def test_s3_file_info(aws_s3_client, s3_uri_object, s3_object_text, mocker):
     assert isinstance(s3_dict["last_modified"], str)
     last_modified = datetime.fromisoformat(s3_dict["last_modified"])
     assert isinstance(last_modified, datetime)
+    # test the JSON representation
+    s3_json = s3_info.json()
+    assert s3_json == json.dumps(s3_dict)
     # the s3 client is used once to get the s3 object data
     assert spy_client.call_count == 1
     assert spy_resource.call_count == 0


### PR DESCRIPTION
Fix https://github.com/dazza-codes/aio-aws/issues/86

This add support to S3URI for pydantic and JSON serialization.


## Notes

This requires a new minor version release because it turns `s3_uri.dict` property into a method.
